### PR TITLE
Add Fantasy ADP integration with local dev proxy, SW hardening, and Gist fallback for GitHub Pages

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,12 @@
 {
-    "gistId": "870a75b6f5a4a7797bc90e6eefdd90a3"
+    "gistId": "870a75b6f5a4a7797bc90e6eefdd90a3",
+    "features": {
+      "showFantasyADP": true,
+      "adp": {
+        "scoring": "ppr",
+        "teams": 10,
+        "year": 2025,
+        "topN": 100
+      }
+    }
   }
-
-  

--- a/index.html
+++ b/index.html
@@ -334,7 +334,51 @@
         const path = scoring === 'standard' ? 'standard' : 'ppr';
         const teams = (adpCfg && adpCfg.teams) || 10;
         const year = (adpCfg && adpCfg.year) || new Date().getFullYear();
+        const isLocal = ['localhost', '127.0.0.1'].includes(window.location.hostname);
+        if (isLocal) {
+          // Use local proxy to bypass CORS during local development
+          return `/proxy/adp?scoring=${encodeURIComponent(path)}&teams=${encodeURIComponent(teams)}&year=${encodeURIComponent(year)}`;
+        }
         return `https://fantasyfootballcalculator.com/api/v1/adp/${path}?teams=${encodeURIComponent(teams)}&year=${encodeURIComponent(year)}`;
+      };
+
+      // --- Gist fallback for ADP ---
+      const pickGistAdpFile = (meta, adpCfg) => {
+        const scoring = (adpCfg && adpCfg.scoring) ? String(adpCfg.scoring).toLowerCase() : 'ppr';
+        const path = scoring === 'standard' ? 'standard' : 'ppr';
+        const teams = (adpCfg && adpCfg.teams) || 10;
+        const year = (adpCfg && adpCfg.year) || new Date().getFullYear();
+        const files = (meta && meta.files) || {};
+        const candidates = [
+          'adp.json',
+          `adp_${path}.json`,
+          `adp_${path}_${teams}.json`,
+          `adp_${path}_${teams}_${year}.json`
+        ];
+        for (const name of candidates) {
+          if (files[name]) return files[name];
+        }
+        // loose fallback: any adp*.json
+        for (const key in files) {
+          if (/^adp.*\.json$/i.test(key)) return files[key];
+        }
+        return null;
+      };
+
+      const fetchADPFromGist = async (adpCfg) => {
+        const id = (gistIdState || localStorage.getItem('gistId') || '').trim();
+        if (!id) throw new Error('no_gist_id');
+        const metaRes = await fetch(`https://api.github.com/gists/${id}`);
+        if (!metaRes.ok) throw new Error(`gist_meta_${metaRes.status}`);
+        const meta = await metaRes.json();
+        const file = pickGistAdpFile(meta, adpCfg);
+        if (!file || !file.raw_url) throw new Error('no_adp_file_in_gist');
+        const rawRes = await fetch(file.raw_url);
+        if (!rawRes.ok) throw new Error(`gist_raw_${rawRes.status}`);
+        const data = await rawRes.json();
+        const players = Array.isArray(data) ? data : (Array.isArray(data && data.players) ? data.players : []);
+        if (!players.length) throw new Error('empty_adp_data');
+        return players;
       };
 
       const fetchFantasyADP = async (adpCfg) => {
@@ -365,9 +409,33 @@
           const limit = (adpCfg && adpCfg.topN) || 100;
           setFantasyADP(normalized.slice(0, Math.max(1, limit)));
         } catch (err) {
-          console.error('ADP fetch failed:', err);
-          setAdpError('Failed to load ADP data.');
-          setFantasyADP([]);
+          console.warn('ADP API fetch failed, attempting Gist fallback:', err);
+          try {
+            const players = await fetchADPFromGist(adpCfg);
+            const normalized = players
+              .filter(p => p && (typeof p.adp === 'number' || typeof p.ADP === 'number') && p.name)
+              .map(p => ({
+                id: p.player_id || p.id,
+                name: p.name,
+                position: p.position,
+                team: p.team,
+                adp: typeof p.adp === 'number' ? p.adp : p.ADP,
+                adpFormatted: p.adp_formatted || String(typeof p.adp === 'number' ? p.adp : p.ADP),
+                timesDrafted: p.times_drafted || p.timesDrafted,
+                high: p.high,
+                low: p.low,
+                stdev: p.stdev,
+                bye: p.bye
+              }))
+              .sort((a, b) => a.adp - b.adp);
+            const limit = (adpCfg && adpCfg.topN) || 100;
+            setFantasyADP(normalized.slice(0, Math.max(1, limit)));
+            setAdpError('Using cached ADP from Gist');
+          } catch (fallbackErr) {
+            console.error('ADP Gist fallback failed:', fallbackErr);
+            setAdpError('Failed to load ADP data from API and Gist.');
+            setFantasyADP([]);
+          }
         } finally {
           setAdpLoading(false);
         }

--- a/index.html
+++ b/index.html
@@ -236,6 +236,15 @@
       const [gistIdState, setGistIdState] = useState((localStorage.getItem('gistId') || '').trim());
       const saveDebounceRef = useRef(null);
       const lastSavedHashRef = useRef('');
+      // Feature flags and Fantasy ADP state
+      const [features, setFeatures] = useState({
+        showFantasyADP: false,
+        adp: { scoring: 'ppr', teams: 10, year: 2025, topN: 100 }
+      });
+      const [fantasyADP, setFantasyADP] = useState([]);
+      const [adpLoading, setAdpLoading] = useState(false);
+      const [adpError, setAdpError] = useState('');
+      const [adpPosition, setAdpPosition] = useState('ALL');
 
       // Manual refresh throttling
       const REFRESH_THROTTLE_MS = 15000; // 15s between manual refreshes
@@ -318,6 +327,66 @@
         }
         throw error || new Error('Fetch failed');
       }
+
+      // --- Fantasy ADP fetch ---
+      const buildAdpUrl = (adpCfg) => {
+        const scoring = (adpCfg && adpCfg.scoring) ? String(adpCfg.scoring).toLowerCase() : 'ppr';
+        const path = scoring === 'standard' ? 'standard' : 'ppr';
+        const teams = (adpCfg && adpCfg.teams) || 10;
+        const year = (adpCfg && adpCfg.year) || new Date().getFullYear();
+        return `https://fantasyfootballcalculator.com/api/v1/adp/${path}?teams=${encodeURIComponent(teams)}&year=${encodeURIComponent(year)}`;
+      };
+
+      const fetchFantasyADP = async (adpCfg) => {
+        try {
+          setAdpLoading(true);
+          setAdpError('');
+          const url = buildAdpUrl(adpCfg);
+          const res = await fetchWithRetry(url, {}, 4, 800, 2);
+          const json = await res.json();
+          const players = Array.isArray(json && json.players) ? json.players : [];
+          const normalized = players
+            .filter(p => p && typeof p.adp === 'number' && p.name)
+            .map(p => ({
+              id: p.player_id,
+              name: p.name,
+              position: p.position,
+              team: p.team,
+              adp: p.adp,
+              adpFormatted: p.adp_formatted,
+              timesDrafted: p.times_drafted,
+              high: p.high,
+              low: p.low,
+              stdev: p.stdev,
+              bye: p.bye
+            }))
+            .sort((a, b) => a.adp - b.adp);
+
+          const limit = (adpCfg && adpCfg.topN) || 100;
+          setFantasyADP(normalized.slice(0, Math.max(1, limit)));
+        } catch (err) {
+          console.error('ADP fetch failed:', err);
+          setAdpError('Failed to load ADP data.');
+          setFantasyADP([]);
+        } finally {
+          setAdpLoading(false);
+        }
+      };
+
+      const fetchADPIfEnabled = async (cfgFeatures) => {
+        const feat = cfgFeatures || features;
+        if (feat && feat.showFantasyADP) {
+          await fetchFantasyADP(feat.adp || features.adp);
+        }
+      };
+
+      const filteredAdp = useMemo(() => {
+        let arr = Array.isArray(fantasyADP) ? fantasyADP : [];
+        if (adpPosition && adpPosition !== 'ALL') {
+          arr = arr.filter(p => String(p.position).toUpperCase() === adpPosition);
+        }
+        return arr;
+      }, [fantasyADP, adpPosition]);
 
       // --- Easter Egg: Live Joke Ticker (continuous stream) ---
       const tickerWrapRef = useRef(null);
@@ -451,14 +520,38 @@
         const timestamp = new Date().getTime();
         // Try to read gistId from config.json
         let gistId = '';
+        let cfgFeatures = null;
         try {
           const cfgRes = await fetch(`config.json?t=${timestamp}`);
           if (cfgRes.ok) {
             const cfg = await cfgRes.json();
             if (cfg && cfg.gistId) gistId = cfg.gistId.trim();
+            if (cfg && cfg.features) {
+              cfgFeatures = cfg.features;
+              setFeatures(prev => ({
+                ...prev,
+                ...cfg.features,
+                adp: { ...prev.adp, ...(cfg.features.adp || {}) }
+              }));
+            }
           }
         } catch (e) {
           // no config found; will fall back below
+        }
+        // LocalStorage ADP override (optional)
+        try {
+          const lsOverrideRaw = localStorage.getItem('adpOverride');
+          if (lsOverrideRaw) {
+            const lsOverride = JSON.parse(lsOverrideRaw);
+            const mergedAdp = { ...((cfgFeatures && cfgFeatures.adp) || features.adp), ...(lsOverride || {}) };
+            setFeatures(prev => ({
+              ...prev,
+              adp: mergedAdp
+            }));
+            cfgFeatures = { ...(cfgFeatures || {}), adp: mergedAdp };
+          }
+        } catch (e) {
+          // ignore bad JSON
         }
         // Fallback to localStorage gistId if not in config
         if (!gistId) {
@@ -482,6 +575,7 @@
             setLastUpdated(data.lastUpdated || '');
             setLoading(false);
             setRefreshing(false);
+            await fetchADPIfEnabled(cfgFeatures);
             return;
           } catch (err) {
             console.error('Gist load failed, falling back to local data.json:', err);
@@ -496,6 +590,7 @@
           setLastUpdated(data.lastUpdated || '');
           setLoading(false);
           setRefreshing(false);
+          await fetchADPIfEnabled(cfgFeatures);
         } catch (error) {
           console.error('Error loading data:', error);
           setLoading(false);
@@ -2109,6 +2204,105 @@
               </div>
             )}
           </section>
+
+          {/* Fantasy ADP Section */}
+          {features.showFantasyADP && (
+            <section className="glass rounded-2xl p-5 overflow-auto animate-fade-in mt-5">
+              <div className="flex items-center justify-between gap-3 flex-wrap">
+                <h2 className="text-xl font-semibold flex items-center gap-2">
+                  <i className="fas fa-list-ol"></i> Fantasy ADP
+                  <span className="ml-2 text-sm px-2 py-0.5 rounded-full bg-purple-600/60">{(features.adp && String(features.adp.scoring).toUpperCase()) || 'PPR'}</span>
+                </h2>
+                <div className="flex items-center gap-2 text-xs text-purple-200">
+                  <span className="px-2 py-0.5 rounded bg-indigo-700/50">Year: {(features.adp && features.adp.year) || new Date().getFullYear()}</span>
+                  <span className="px-2 py-0.5 rounded bg-indigo-700/50">Teams: {(features.adp && features.adp.teams) || 10}</span>
+                  <span className="px-2 py-0.5 rounded bg-indigo-700/50">Top: {(features.adp && features.adp.topN) || 100}</span>
+                </div>
+              </div>
+
+              {/* Controls */}
+              <div className="mt-4 flex items-center gap-3 flex-wrap">
+                <div className="inline-flex rounded overflow-hidden border border-white/10">
+                  {['ALL','RB','WR','QB','TE'].map(pos => (
+                    <button
+                      key={pos}
+                      onClick={() => setAdpPosition(pos)}
+                      className={`px-3 py-1 text-sm ${adpPosition === pos ? 'bg-purple-600' : 'bg-indigo-800/40 hover:bg-indigo-700/40'}`}
+                    >{pos}</button>
+                  ))}
+                </div>
+                <button
+                  onClick={() => fetchFantasyADP(features.adp)}
+                  className="px-3 py-1 text-sm rounded bg-purple-600 hover:bg-purple-700"
+                  disabled={adpLoading}
+                >
+                  <i className={`fas fa-sync-alt mr-1 ${adpLoading ? 'animate-rotate' : ''}`}></i>
+                  Refresh ADP
+                </button>
+              </div>
+
+              {/* States */}
+              {adpLoading && (
+                <div className="text-center py-6 text-purple-200">Loading ADP...</div>
+              )}
+              {!adpLoading && adpError && (
+                <div className="text-center py-6">
+                  <p className="text-red-300 mb-2">{adpError}</p>
+                  <button onClick={() => fetchFantasyADP(features.adp)} className="px-3 py-1 text-sm rounded bg-purple-600 hover:bg-purple-700">Try Again</button>
+                </div>
+              )}
+
+              {!adpLoading && !adpError && filteredAdp.length > 0 && (
+                <>
+                  {/* Desktop table */}
+                  <div className="hidden md:block overflow-x-auto mt-4">
+                    <table className="w-full text-sm">
+                      <thead className="bg-indigo-800/40">
+                        <tr>
+                          <th className="p-2 text-center">#</th>
+                          <th className="p-2 text-left">Player</th>
+                          <th className="p-2 text-center">Pos</th>
+                          <th className="p-2 text-center">Team</th>
+                          <th className="p-2 text-center">ADP</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {filteredAdp.map((p, idx) => (
+                          <tr key={p.id || idx} className={idx % 2 === 0 ? 'bg-indigo-700/30' : 'bg-indigo-700/20'}>
+                            <td className="p-2 text-center font-mono">{idx + 1}</td>
+                            <td className="p-2">
+                              <div className="font-medium">{p.name}</div>
+                            </td>
+                            <td className="p-2 text-center">{p.position}</td>
+                            <td className="p-2 text-center">{p.team}</td>
+                            <td className="p-2 text-center font-mono">{p.adpFormatted || p.adp}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {/* Mobile cards */}
+                  <div className="md:hidden mt-4 space-y-2">
+                    {filteredAdp.map((p, idx) => (
+                      <div key={p.id || idx} className="rounded-lg bg-indigo-900/30 p-3">
+                        <div className="flex items-center justify-between">
+                          <div className="text-xs px-2 py-0.5 rounded-full bg-purple-300 text-black font-semibold">#{idx + 1}</div>
+                          <div className="text-xs text-purple-200 font-mono">ADP: {p.adpFormatted || p.adp}</div>
+                        </div>
+                        <div className="mt-1 font-semibold">{p.name}</div>
+                        <div className="text-sm text-purple-200">{p.position} • {p.team}</div>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
+
+              {!adpLoading && !adpError && filteredAdp.length === 0 && (
+                <div className="text-center py-6 text-purple-200">No ADP data available.</div>
+              )}
+            </section>
+          )}
 
           {/* Mobile Refresh FAB */}
           <button

--- a/server.py
+++ b/server.py
@@ -1,26 +1,72 @@
 from http.server import SimpleHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+from urllib.request import Request, urlopen
 import json
 import os
 
+TARGET_BASE = 'https://fantasyfootballcalculator.com/api/v1/adp'
+
 class CustomHandler(SimpleHTTPRequestHandler):
+    # Ensure CORS headers on all responses
+    def end_headers(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type, Authorization, *')
+        return super().end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self.end_headers()
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == '/proxy/adp':
+            # Example: /proxy/adp?scoring=ppr&teams=10&year=2025
+            qs = parse_qs(parsed.query)
+            scoring = (qs.get('scoring', ['ppr'])[0] or 'ppr').lower()
+            scoring = 'standard' if scoring == 'standard' else 'ppr'
+            teams = qs.get('teams', ['10'])[0]
+            year = qs.get('year', [str(os.getenv('ADP_YEAR', '2025'))])[0]
+            target = f"{TARGET_BASE}/{scoring}?teams={teams}&year={year}"
+            try:
+                req = Request(target, headers={'User-Agent': 'Mozilla/5.0'})
+                with urlopen(req, timeout=10) as resp:
+                    data = resp.read()
+                    self.send_response(200)
+                    self.send_header('Content-Type', 'application/json')
+                    self.end_headers()
+                    self.wfile.write(data)
+            except Exception as e:
+                self.send_response(502)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps({'error': 'proxy_failed', 'detail': str(e)}).encode('utf-8'))
+            return
+
+        # Fall back to static file serving
+        return super().do_GET()
+
     def do_POST(self):
         if self.path == '/':
-            content_length = int(self.headers['Content-Length'])
+            content_length = int(self.headers.get('Content-Length', '0') or '0')
             post_data = self.rfile.read(content_length)
-            data = json.loads(post_data.decode('utf-8'))
+            try:
+                data = json.loads(post_data.decode('utf-8'))
+            except Exception:
+                data = {}
             filename = data.get('filename', 'data.json')
             content = data.get('content', '')
-            with open(filename, 'w') as f:
+            with open(filename, 'w', encoding='utf-8') as f:
                 f.write(content)
             self.send_response(200)
             self.send_header('Content-type', 'application/json')
             self.end_headers()
-            self.wfile.write(json.dumps({'success': True}).encode())
+            self.wfile.write(json.dumps({'success': True}).encode('utf-8'))
         else:
             super().do_POST()
 
 if __name__ == '__main__':
-    port = 8000
+    port = int(os.getenv('PORT', '8000'))
     server = HTTPServer(('', port), CustomHandler)
-    print(f'Server running on port {port}')
+    print(f'Server running on http://127.0.0.1:{port}')
     server.serve_forever()


### PR DESCRIPTION
Summary
This PR integrates Fantasy Football Calculator ADP into the site, gated by a feature flag, with:

Local development CORS proxy.
Service worker adjustments to avoid cross-origin interception and stale dynamic data.
Gist-based ADP fallback for production (GitHub Pages) to bypass CORS, matching your client-only preference.
Changes
index.html
Adds feature state for ADP and UI (top-100 with position filters).
Implements robust fetchFantasyADP() with retry/backoff.
Adds buildAdpUrl() to route:
Localhost → /proxy/adp (dev-only, bypass CORS).
Production → direct FFC API by default.
Adds Gist fallback:
pickGistAdpFile(meta, adpCfg) picks from adp.json, adp_ppr.json, adp_ppr_10.json, adp_ppr_10_2025.json, or any adp*.json.
fetchADPFromGist(adpCfg) fetches from 
config.json
’s gistId or localStorage.
Normalizes data (supports FFC-style { players: [] } and raw array formats).
server.py
Adds GET /proxy/adp proxy to FFC API with permissive CORS headers for local testing.
Handles OPTIONS and returns JSON on errors.
sw.js
Skips cross-origin fetch interception.
Treats /proxy/* network-first with no caching.
Returns a safe Response on total failure for non-HTML requests.
Motivation
Local testing was blocked by CORS from FFC.
GitHub Pages is static-only, so a serverless fallback is required.
Gist fallback keeps the site client-only and aligns with your preference to avoid manual data commits.
Configuration
config.json
features.showFantasyADP: true to enable the feature.
features.adp: { scoring: 'ppr', teams: 10, year: 2025, topN: 100 }
gistId: already set and used by the fallback loader.
Testing
Local (dev proxy)
Run: python server.py
Open: http://127.0.0.1/:8000
Hard-refresh (service worker).
Verify GET /proxy/adp?... returns 200 and ADP UI renders with filters.
GitHub Pages (Gist fallback)
Seed the Gist with adp_ppr_10_2025.json (or adp.json / adp_ppr.json / adp_ppr_10.json).
Hard-refresh on Pages.
Expected: direct API may be CORS-blocked; app falls back to Gist and shows “Using cached ADP from Gist”.
Data formats supported in Gist
FFC-style:
{ "players": [ { "name": "...", "position": "WR", "team": "BUF", "adp": 15.3, ... } ] }
Raw array:
[ { "name": "...", "position": "WR", "team": "BUF", "ADP": 15.3, ... } ]
Minimum fields used: name, position, team, and adp (or ADP). Sorted by adp. Limited by topN (default 100).

Screenshots
Recommended: capture the ADP table on desktop and card layout on mobile.
Include one screenshot showing the Gist fallback banner text.
Risks / Trade-offs
If Gist isn’t seeded, fallback will fail; the UI shows an error.
Using FFC directly on Pages may CORS-fail; that’s expected, and fallback will engage if Gist exists.
Rollback
Set features.showFantasyADP to false in 
config.json
 to disable the feature instantly.
Revert this PR if needed; no schema changes to persisted data.
Follow-ups
Seed Gist with adp_ppr_10_2025.json and validate structure.
Optionally add admin import/export to update the Gist from the UI.
Optionally add a hosted proxy for production (e.g., Cloudflare Worker) and wire proxyBase in 
config.json
 for API-first behavior on Pages.
Checklist
 Feature flag added and respected
 Local dev proxy works (/proxy/adp)
 Service worker avoids cross-origin interception and proxy caching
 Gist fallback implemented and documented
 Gist seeded with ADP file in expected format
 Verified on GitHub Pages (fallback path)