### PR TITLE
Prepare site for 2026 NFL preseason

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,51 @@
 # Howboutit-survivor-pool
-NFL Preseason Survivor Pool Tracker
+
+2026 NFL Preseason Survivor Pool Tracker
 
 ## Overview
-Single-page React app (vanilla React via `<script>` in `index.html`) hosted on GitHub Pages. Tracks a preseason NFL survivor pool with live scores, draft-order logic, manager cards, and an admin panel (`admin.html`) for data edits (persisted to a GitHub Gist).
 
-## Performance & UX Enhancements (2025 Q3)
+Single-page React app (vanilla React via `<script>` in `index.html`) hosted on GitHub Pages. It tracks preseason picks, live scores, cumulative margins, eliminations, and fantasy draft order. The companion `admin.html` page manages picks and can persist them to a GitHub Gist.
 
-• **Manual Refresh Throttling**
-  - The toolbar and stale banner refresh buttons are throttled to 15 seconds.
-  - When on cooldown, the button is disabled and shows a countdown in the tooltip/label.
+## 2026 Season
 
-• **Memoized Derived Computations**
-  - Draft ordering and elimination ranking are memoized via `useMemo` and reused across the UI.
-  - The Stats Overview counts use `orderedManagers` (which includes `eliminationWeek`) to avoid recomputation.
+- The active pool covers official preseason Weeks 1-3, August 13-29, 2026. The standalone Hall of Fame Game is excluded.
+- `data.json` is reset for the ten returning managers. Their `lastYearRank` values are the final 2025 pool order and serve as the last tiebreaker.
+- The final 2025 Gist snapshot is preserved in `data-2025.json`.
+- Active data must contain `"season": 2026`. Until the configured Gist is updated for 2026, both pages ignore its 2025 data and safely use the repository's starter `data.json`.
+- After deployment, open `admin.html` and use **Save to Gist** once to initialize the Gist for 2026. Gist revision history preserves the prior version as an additional backup.
 
-• **Audio Lazy-Load + Global Mute**
-  - Easter egg audio assets now load lazily (`preload="none"`).
-  - A global mute toggle in the toolbar controls all easter-eggs and persists to `localStorage`.
-  - Local storage key: `mutedAudio` = `"true" | "false"`.
+## Current Features
 
-## Data & Persistence
-• Public reads from this repo’s `data.json` or a configured GitHub Gist.
-• Admin writes from `admin.html` to the configured Gist (token stored client-side; low security acceptable for this project).
-• Live NFL scores via ESPN public scoreboard API.
+- Manual refresh is throttled to 15 seconds.
+- Draft ordering and elimination calculations are memoized.
+- ESPN preseason scores refresh every two minutes with retry/backoff.
+- Picks lock at their explicit Eastern Time kickoff.
+- Audio assets lazy-load and a global mute preference persists in `localStorage`.
+- The admin validates data and previews changes before saving to the Gist.
+
+## Data and Persistence
+
+- Public reads use the configured GitHub Gist only when it matches the active season; otherwise they fall back to `data.json`.
+- Admin writes require a Gist token stored in the browser. This client-side setup is acceptable for this private league tool but should not be treated as secure.
+- Optional public auto-persist includes the season, managers, game results, and update timestamp. It remains disabled until the Gist already contains 2026 data.
+- Fantasy ADP is configured for 2026 in `config.json`.
 
 ## Local Development
-1) Open `index.html` in a local server (or use GitHub Pages). No build step required.
-2) Optional: open `admin.html` to edit managers/results and save to your Gist.
-3) Environment/state
-   - `localStorage.gistId` and `localStorage.gistToken` for admin saves.
-   - `localStorage.autoPersistEnabled` toggles auto-save of live state.
-   - `localStorage.mutedAudio` persists the global mute toggle.
+
+1. Start a local web server in the repository (for example, `python -m http.server 8000`).
+2. Open `http://localhost:8000/` for the public site.
+3. Open `http://localhost:8000/admin.html` for administration.
+4. There is no build step.
+
+Browser state:
+
+- `localStorage.gistId` and `localStorage.gistToken` configure Gist saves.
+- `localStorage.autoPersistEnabled` toggles automatic live-result saves.
+- `localStorage.mutedAudio` persists the global mute setting.
+- The default admin password for a new browser is `survivor2026`; change it after first login.
 
 ## Notes
-• The per-manager margins table includes a Running Total that sums decided games (W/L); ties contribute 0 and are displayed as 0.
-• Times shown are Eastern Time; kickoff lock indicators are derived from live state where possible, with ET as fallback.
+
+- Times are displayed in Eastern Time.
+- Ties contribute zero and do not eliminate a manager.
+- Draft order is based on survival, cumulative margin, active/elimination-week margin, then the prior year's finish.

--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Admin Panel - NFL Survivor Pool</title>
+  <title>2026 Admin Panel - NFL Survivor Pool</title>
   <!-- Tailwind CSS via Play CDN for rapid styling -->
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- React and ReactDOM -->
@@ -14,7 +14,7 @@
   <!-- Font Awesome for icons -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <!-- Ajv for JSON Schema validation -->
-  <script src="https://cdn.jsdelivr.net/npm/ajv@8/dist/ajv.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.17.1/ajv7.bundle.min.js"></script>
   <!-- diff for computing text diffs (line-by-line) -->
   <script src="https://cdn.jsdelivr.net/npm/diff@5/dist/diff.min.js"></script>
   <style>
@@ -88,6 +88,8 @@
 
   <script type="text/babel">
     const { useState, useEffect, useRef } = React;
+    const SEASON_YEAR = 2026;
+    const isCurrentSeasonData = (data) => Number(data && data.season) === SEASON_YEAR;
     
     // Complete list of NFL teams
     const nflTeams = [
@@ -161,9 +163,10 @@
       // Lightweight JSON Schema for admin validation (kept permissive to avoid blocking legitimate data)
       const jsonSchema = {
         type: 'object',
-        required: ['managers'],
+        required: ['season', 'managers'],
         additionalProperties: true,
         properties: {
+          season: { type: 'integer', const: SEASON_YEAR },
           managers: {
             type: 'array',
             items: {
@@ -203,17 +206,18 @@
 
       const getDataToSave = () => ({
         ...completeData,
+        season: SEASON_YEAR,
         managers: managers,
         lastUpdated: new Date().toISOString()
       });
 
       const validateAgainstSchema = (data) => {
-        if (!window.Ajv) {
+        if (!window.ajv7) {
           console.warn('Ajv not loaded; skipping validation');
           return { valid: true, errors: [] };
         }
         try {
-          const ajv = new Ajv({ allErrors: true, strict: false });
+          const ajv = new window.ajv7({ allErrors: true, strict: false });
           const validate = ajv.compile(jsonSchema);
           const valid = validate(data);
           return { valid: !!valid, errors: validate.errors || [] };
@@ -256,7 +260,7 @@
       };
       
       const handleLogin = () => {
-        const storedPassword = localStorage.getItem('adminPassword') || 'survivor2025';
+        const storedPassword = localStorage.getItem('adminPassword') || 'survivor2026';
         if (password === storedPassword) {
           setAuthenticated(true);
           localStorage.setItem('adminAuthenticated', 'true');
@@ -291,6 +295,7 @@
       };
       
       const loadData = async () => {
+        let ignoredPriorSeasonGist = false;
         // Try Gist first if configured; otherwise fall back to local data.json
         if (gistId) {
           try {
@@ -302,6 +307,12 @@
             const res = await fetch(`${dataFile.raw_url}?t=${Date.now()}`);
             if (!res.ok) throw new Error(`Gist raw fetch failed: ${res.status}`);
             const data = await res.json();
+            if (!isCurrentSeasonData(data)) {
+              ignoredPriorSeasonGist = true;
+              const mismatchError = new Error(`Ignoring non-${SEASON_YEAR} Gist data`);
+              mismatchError.code = 'season_mismatch';
+              throw mismatchError;
+            }
             setManagers(data.managers || []);
             setCompleteData(data);
             setJsonData(JSON.stringify(data, null, 2));
@@ -309,17 +320,27 @@
             setDirty(false);
             return;
           } catch (err) {
-            console.error('Gist load failed, falling back to local data.json:', err);
+            if (err && err.code === 'season_mismatch') {
+              console.info(`[Data] ${SEASON_YEAR} starter data loaded; prior-season Gist left untouched.`);
+            } else {
+              console.error('Gist load failed, falling back to local data.json:', err);
+            }
           }
         }
         try {
           const res = await fetch(`data.json?t=${Date.now()}`);
           const data = await res.json();
+          if (!isCurrentSeasonData(data)) {
+            throw new Error(`Local data.json is not configured for ${SEASON_YEAR}`);
+          }
           setManagers(data.managers || []);
           setCompleteData(data);
           setJsonData(JSON.stringify(data, null, 2));
           setBaselineJson(JSON.stringify(data, null, 2));
           setDirty(false);
+          if (ignoredPriorSeasonGist) {
+            showNotification(`Loaded ${SEASON_YEAR} starter data; last season's Gist was left untouched`, 'success');
+          }
         } catch (error) {
           console.error('Error loading local data.json:', error);
           showNotification('Error loading data', 'error');
@@ -410,6 +431,7 @@
       const updateJsonData = (updatedManagers) => {
         const data = {
           ...completeData,  // Preserve existing data like gameResults
+          season: SEASON_YEAR,
           managers: updatedManagers,
           lastUpdated: new Date().toISOString()
         };
@@ -443,6 +465,9 @@
           const data = JSON.parse(text);
           if (!data || typeof data !== 'object' || !Array.isArray(data.managers)) {
             throw new Error('Invalid JSON format: expected { managers: [...] }');
+          }
+          if (!isCurrentSeasonData(data)) {
+            throw new Error(`Import must contain season: ${SEASON_YEAR}`);
           }
           // Preserve entire structure (e.g., gameResults) and reflect it in state
           const importedManagers = Array.isArray(data.managers) ? data.managers : [];
@@ -649,7 +674,7 @@
               </div>
               
               <div className="mt-6 text-center text-sm text-purple-300">
-                <p>Default password: <span className="font-mono">survivor2025</span></p>
+                <p>Default password: <span className="font-mono">survivor2026</span></p>
                 <p className="mt-2">Change this after first login for security</p>
               </div>
             </div>
@@ -666,9 +691,9 @@
                 <div>
                   <h1 className="text-3xl font-bold flex items-center gap-3">
                     <i className="fas fa-user-shield"></i>
-                    Admin Panel
+                    {SEASON_YEAR} Admin Panel
                   </h1>
-                  <p className="text-purple-200 mt-1">Manage your NFL Survivor Pool</p>
+                  <p className="text-purple-200 mt-1">Manage your {SEASON_YEAR} NFL Survivor Pool</p>
                 </div>
                 <div className="flex flex-wrap gap-3">
                   <button

--- a/config.json
+++ b/config.json
@@ -1,11 +1,12 @@
 {
+    "season": 2026,
     "gistId": "870a75b6f5a4a7797bc90e6eefdd90a3",
     "features": {
       "showFantasyADP": true,
       "adp": {
         "scoring": "ppr",
         "teams": 10,
-        "year": 2025,
+        "year": 2026,
         "topN": 100,
         "proxyBase": "https://curly-wind-d55c.enjoinick.workers.dev"
       }

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,11 +1,12 @@
 {
+  "season": 2026,
   "gistId": "YOUR_GIST_ID_HERE",
   "features": {
     "showFantasyADP": true,
     "adp": {
       "scoring": "ppr",
       "teams": 10,
-      "year": 2025,
+      "year": 2026,
       "topN": 100,
       "proxyBase": ""
     }

--- a/data-2025.json
+++ b/data-2025.json
@@ -1,0 +1,466 @@
+{
+  "season": 2025,
+  "managers": [
+    {
+      "name": "Chris",
+      "teamLabel": "Hello Naber!",
+      "lastYearRank": 1,
+      "picks": [
+        {
+          "week": 1,
+          "team": "Tampa Bay Buccaneers",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-14T14:04:07.163Z",
+          "margin": 22
+        },
+        {
+          "week": 2,
+          "team": "Detroit Lions",
+          "result": "L",
+          "manualResult": true,
+          "lastUpdated": "2025-08-21T13:26:49.298Z",
+          "margin": -7
+        },
+        {
+          "week": 3,
+          "team": "",
+          "result": null
+        }
+      ],
+      "eliminated": true,
+      "marginOfVictory": 22
+    },
+    {
+      "name": "Josh",
+      "teamLabel": "S K",
+      "lastYearRank": 2,
+      "picks": [
+        {
+          "week": 1,
+          "team": "Detroit Lions",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-14T14:04:27.035Z",
+          "margin": 7
+        },
+        {
+          "week": 2,
+          "team": "Indianapolis Colts",
+          "result": "L",
+          "manualResult": true,
+          "lastUpdated": "2025-08-16T20:40:07.677Z",
+          "margin": -4
+        },
+        {
+          "week": 3,
+          "team": "",
+          "result": null
+        }
+      ],
+      "eliminated": true,
+      "marginOfVictory": 7
+    },
+    {
+      "name": "Kevin",
+      "teamLabel": "Check My Balls",
+      "lastYearRank": 3,
+      "picks": [
+        {
+          "week": 1,
+          "team": "Baltimore Ravens",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-14T14:07:16.968Z",
+          "margin": 8
+        },
+        {
+          "week": 2,
+          "team": "Cleveland Browns",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-21T13:25:48.885Z",
+          "margin": 9
+        },
+        {
+          "week": 3,
+          "team": "New York Giants",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-09-02T14:29:44.651Z",
+          "margin": 32
+        }
+      ],
+      "eliminated": false,
+      "marginOfVictory": 49
+    },
+    {
+      "name": "Austin",
+      "teamLabel": "Honey Baked Lamb",
+      "lastYearRank": 4,
+      "picks": [
+        {
+          "week": 1,
+          "team": "Carolina Panthers",
+          "result": "L",
+          "manualResult": true,
+          "lastUpdated": "2025-08-14T14:10:11.370Z",
+          "margin": -20
+        },
+        {
+          "week": 2,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 3,
+          "team": "",
+          "result": null
+        }
+      ],
+      "eliminated": true,
+      "eliminatedWeek": 1,
+      "marginOfVictory": 0
+    },
+    {
+      "name": "Ryan",
+      "teamLabel": "Quail Man SWAG",
+      "lastYearRank": 5,
+      "buyback": true,
+      "carryMargin": -7,
+      "picks": [
+        {
+          "week": 1,
+          "team": "Cincinnati Bengals",
+          "result": "L",
+          "manualResult": true,
+          "lastUpdated": "2025-08-14T14:07:41.113Z",
+          "margin": -7
+        },
+        {
+          "week": 2,
+          "team": "Denver Broncos",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-21T13:27:58.458Z",
+          "margin": 20
+        },
+        {
+          "week": 3,
+          "team": "Cleveland Browns",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-09-02T14:30:03.851Z",
+          "margin": 2
+        }
+      ],
+      "eliminated": true,
+      "marginOfVictory": 22
+    },
+    {
+      "name": "Weston",
+      "teamLabel": "Robert DUUUVAL",
+      "lastYearRank": 6,
+      "picks": [
+        {
+          "week": 1,
+          "team": "Jacksonville Jaguars",
+          "result": "L",
+          "margin": -6,
+          "manualResult": true,
+          "lastUpdated": "2025-08-14T14:09:10.152Z"
+        },
+        {
+          "week": 2,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 3,
+          "team": "",
+          "result": null
+        }
+      ],
+      "eliminated": true,
+      "eliminatedWeek": 1,
+      "marginOfVictory": 0
+    },
+    {
+      "name": "Jordan",
+      "teamLabel": "GRAVEDIGGER",
+      "lastYearRank": 7,
+      "picks": [
+        {
+          "week": 1,
+          "team": "Cleveland Browns",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-14T14:05:26.191Z",
+          "margin": 20
+        },
+        {
+          "week": 2,
+          "team": "Houston Texans",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-19T18:53:21.661Z",
+          "margin": 17
+        },
+        {
+          "week": 3,
+          "team": "Pittsburgh Steelers",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-09-02T14:32:33.898Z",
+          "margin": 9
+        }
+      ],
+      "eliminated": false,
+      "marginOfVictory": 46
+    },
+    {
+      "name": "Matt",
+      "teamLabel": "DELTA 8",
+      "lastYearRank": 8,
+      "picks": [
+        {
+          "week": 1,
+          "team": "Houston Texans",
+          "result": "L",
+          "manualResult": true,
+          "lastUpdated": "2025-08-14T14:08:37.050Z",
+          "margin": -10
+        },
+        {
+          "week": 2,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 3,
+          "team": "",
+          "result": null
+        }
+      ],
+      "eliminated": true,
+      "eliminatedWeek": 1,
+      "marginOfVictory": 0
+    },
+    {
+      "name": "Nick",
+      "teamLabel": "Allen's Dirty Brown Kupp",
+      "lastYearRank": 9,
+      "picks": [
+        {
+          "week": 1,
+          "team": "Las Vegas Raiders",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-14T14:06:09.857Z",
+          "margin": 0
+        },
+        {
+          "week": 2,
+          "team": "New England Patriots",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-21T13:26:32.282Z",
+          "margin": 8
+        },
+        {
+          "week": 3,
+          "team": "Kansas City Chiefs",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-09-02T14:31:04.701Z",
+          "margin": 2
+        }
+      ],
+      "eliminated": false,
+      "marginOfVictory": 10
+    },
+    {
+      "name": "Will",
+      "teamLabel": "Just Win Baby",
+      "lastYearRank": 10,
+      "picks": [
+        {
+          "week": 1,
+          "team": "Philadelphia Eagles",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-14T14:05:56.427Z",
+          "margin": 7
+        },
+        {
+          "week": 2,
+          "team": "New York Giants",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-08-21T13:25:31.805Z",
+          "margin": 19
+        },
+        {
+          "week": 3,
+          "team": "Denver Broncos",
+          "result": "W",
+          "manualResult": true,
+          "lastUpdated": "2025-09-02T14:31:25.164Z",
+          "margin": 9
+        }
+      ],
+      "eliminated": false,
+      "marginOfVictory": 35
+    }
+  ],
+  "gameResults": {
+    "week1": [
+      {
+        "date": "2025-08-07",
+        "matchup": "Indianapolis Colts at Baltimore Ravens",
+        "homeTeam": "Baltimore Ravens",
+        "awayTeam": "Indianapolis Colts",
+        "homeScore": 24,
+        "awayScore": 16,
+        "winner": "Baltimore Ravens"
+      },
+      {
+        "date": "2025-08-07",
+        "matchup": "Cincinnati Bengals at Philadelphia Eagles",
+        "homeTeam": "Philadelphia Eagles",
+        "awayTeam": "Cincinnati Bengals",
+        "homeScore": 34,
+        "awayScore": 27,
+        "winner": "Philadelphia Eagles"
+      },
+      {
+        "date": "2025-08-07",
+        "matchup": "Las Vegas Raiders at Seattle Seahawks",
+        "homeTeam": "Seattle Seahawks",
+        "awayTeam": "Las Vegas Raiders",
+        "homeScore": 23,
+        "awayScore": 23,
+        "winner": "Tie"
+      },
+      {
+        "date": "2025-08-08",
+        "matchup": "Cleveland Browns at Carolina Panthers",
+        "homeTeam": "Carolina Panthers",
+        "awayTeam": "Cleveland Browns",
+        "homeScore": 10,
+        "awayScore": 30,
+        "winner": "Cleveland Browns"
+      },
+      {
+        "date": "2025-08-08",
+        "matchup": "Detroit Lions at Atlanta Falcons",
+        "homeTeam": "Atlanta Falcons",
+        "awayTeam": "Detroit Lions",
+        "homeScore": 10,
+        "awayScore": 17,
+        "winner": "Detroit Lions",
+        "note": "Game ended early"
+      },
+      {
+        "date": "2025-08-08",
+        "matchup": "Washington Commanders at New England Patriots",
+        "homeTeam": "New England Patriots",
+        "awayTeam": "Washington Commanders",
+        "homeScore": 48,
+        "awayScore": 18,
+        "winner": "New England Patriots"
+      },
+      {
+        "date": "2025-08-09",
+        "matchup": "New York Giants at Buffalo Bills",
+        "homeTeam": "Buffalo Bills",
+        "awayTeam": "New York Giants",
+        "homeScore": 25,
+        "awayScore": 34,
+        "winner": "New York Giants"
+      },
+      {
+        "date": "2025-08-09",
+        "matchup": "Houston Texans at Minnesota Vikings",
+        "homeTeam": "Minnesota Vikings",
+        "awayTeam": "Houston Texans",
+        "homeScore": 20,
+        "awayScore": 10,
+        "winner": "Minnesota Vikings"
+      },
+      {
+        "date": "2025-08-09",
+        "matchup": "Pittsburgh Steelers at Jacksonville Jaguars",
+        "homeTeam": "Jacksonville Jaguars",
+        "awayTeam": "Pittsburgh Steelers",
+        "homeScore": 25,
+        "awayScore": 31,
+        "winner": "Pittsburgh Steelers"
+      },
+      {
+        "date": "2025-08-09",
+        "matchup": "Tennessee Titans at Tampa Bay Buccaneers",
+        "homeTeam": "Tampa Bay Buccaneers",
+        "awayTeam": "Tennessee Titans",
+        "homeScore": 29,
+        "awayScore": 7,
+        "winner": "Tampa Bay Buccaneers"
+      },
+      {
+        "date": "2025-08-09",
+        "matchup": "Kansas City Chiefs at Arizona Cardinals",
+        "homeTeam": "Arizona Cardinals",
+        "awayTeam": "Kansas City Chiefs",
+        "homeScore": 20,
+        "awayScore": 17,
+        "winner": "Arizona Cardinals"
+      },
+      {
+        "date": "2025-08-09",
+        "matchup": "New York Jets at Green Bay Packers",
+        "homeTeam": "Green Bay Packers",
+        "awayTeam": "New York Jets",
+        "homeScore": 10,
+        "awayScore": 30,
+        "winner": "New York Jets"
+      },
+      {
+        "date": "2025-08-09",
+        "matchup": "Denver Broncos at San Francisco 49ers",
+        "homeTeam": "San Francisco 49ers",
+        "awayTeam": "Denver Broncos",
+        "homeScore": 9,
+        "awayScore": 30,
+        "winner": "Denver Broncos"
+      },
+      {
+        "date": "2025-08-09",
+        "matchup": "Dallas Cowboys at Los Angeles Rams",
+        "homeTeam": "Los Angeles Rams",
+        "awayTeam": "Dallas Cowboys",
+        "homeScore": 31,
+        "awayScore": 21,
+        "winner": "Los Angeles Rams"
+      },
+      {
+        "date": "2025-08-10",
+        "matchup": "New Orleans Saints at Los Angeles Chargers",
+        "homeTeam": "Los Angeles Chargers",
+        "awayTeam": "New Orleans Saints",
+        "homeScore": 27,
+        "awayScore": 13,
+        "winner": "Los Angeles Chargers"
+      },
+      {
+        "date": "2025-08-10",
+        "matchup": "Miami Dolphins at Chicago Bears",
+        "homeTeam": "Chicago Bears",
+        "awayTeam": "Miami Dolphins",
+        "homeScore": 24,
+        "awayScore": 24,
+        "winner": "Tie"
+      }
+    ]
+  },
+  "lastUpdated": "2025-09-02T14:32:51.143Z"
+}

--- a/data.json
+++ b/data.json
@@ -1,24 +1,20 @@
 {
+  "season": 2026,
   "managers": [
     {
-      "name": "Chris",
-      "teamLabel": "Hello Naber!",
+      "name": "Kevin",
+      "teamLabel": "Check My Balls",
       "lastYearRank": 1,
       "picks": [
         {
           "week": 1,
-          "team": "Tampa Bay Buccaneers",
-          "result": "W",
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:04:07.163Z",
-          "margin": 22
+          "team": "",
+          "result": null
         },
         {
           "week": 2,
-          "team": "Detroit Lions",
-          "result": null,
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:04:15.306Z"
+          "team": "",
+          "result": null
         },
         {
           "week": 3,
@@ -27,173 +23,22 @@
         }
       ],
       "eliminated": false,
-      "marginOfVictory": 22
-    },
-    {
-      "name": "Josh",
-      "teamLabel": "S K",
-      "lastYearRank": 2,
-      "picks": [
-        {
-          "week": 1,
-          "team": "Detroit Lions",
-          "result": "W",
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:04:27.035Z",
-          "margin": 3
-        },
-        {
-          "week": 2,
-          "team": "Indianapolis Colts",
-          "result": null,
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:07:28.580Z"
-        },
-        {
-          "week": 3,
-          "team": "",
-          "result": null
-        }
-      ],
-      "eliminated": false,
-      "marginOfVictory": 7
-    },
-    {
-      "name": "Kevin",
-      "teamLabel": "Check My Balls",
-      "lastYearRank": 3,
-      "picks": [
-        {
-          "week": 1,
-          "team": "Baltimore Ravens",
-          "result": "W",
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:07:16.968Z",
-          "margin": 8
-        },
-        {
-          "week": 2,
-          "team": "Cleveland Browns",
-          "result": null,
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:07:12.548Z"
-        },
-        {
-          "week": 3,
-          "team": "",
-          "result": null
-        }
-      ],
-      "eliminated": false,
-      "marginOfVictory": 8
-    },
-    {
-      "name": "Austin",
-      "teamLabel": "Honey Baked Lamb",
-      "lastYearRank": 4,
-      "picks": [
-        {
-          "week": 1,
-          "team": "Carolina Panthers",
-          "result": "L",
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:10:11.370Z",
-          "margin": -20
-        },
-        {
-          "week": 2,
-          "team": "",
-          "result": null
-        },
-        {
-          "week": 3,
-          "team": "",
-          "result": null
-        }
-      ],
-      "eliminated": true,
-      "eliminatedWeek": 1,
-      "marginOfVictory": 0
-    },
-    {
-      "name": "Ryan",
-      "teamLabel": "Quail Man SWAG",
-      "lastYearRank": 5,
-      "buyback": true,
-      "carryMargin": -7,
-      "picks": [
-        {
-          "week": 1,
-          "team": "Cincinnati Bengals",
-          "result": "L",
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:07:41.113Z",
-          "margin": -7
-        },
-        {
-          "week": 2,
-          "team": "Denver Broncos",
-          "result": "W",
-          "manualResult": true,
-          "lastUpdated": "2025-08-17T12:22:20.000Z",
-          "margin": 20
-        },
-        {
-          "week": 3,
-          "team": "",
-          "result": null
-        }
-      ],
-      "eliminated": false,
-      "marginOfVictory": 13
-    },
-    {
-      "name": "Weston",
-      "teamLabel": "Robert DUUUVAL",
-      "lastYearRank": 6,
-      "picks": [
-        {
-          "week": 1,
-          "team": "Jacksonville Jaguars",
-          "result": "L",
-          "margin": -6,
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:09:10.152Z"
-        },
-        {
-          "week": 2,
-          "team": "",
-          "result": null
-        },
-        {
-          "week": 3,
-          "team": "",
-          "result": null
-        }
-      ],
-      "eliminated": true,
-      "eliminatedWeek": 1,
       "marginOfVictory": 0
     },
     {
       "name": "Jordan",
       "teamLabel": "GRAVEDIGGER",
-      "lastYearRank": 7,
+      "lastYearRank": 2,
       "picks": [
         {
           "week": 1,
-          "team": "Cleveland Browns",
-          "result": "W",
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:05:26.191Z",
-          "margin": 20
+          "team": "",
+          "result": null
         },
         {
           "week": 2,
-          "team": "Houston Texans",
-          "result": null,
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:05:24.487Z"
+          "team": "",
+          "result": null
         },
         {
           "week": 3,
@@ -202,20 +47,17 @@
         }
       ],
       "eliminated": false,
-      "marginOfVictory": 20
+      "marginOfVictory": 0
     },
     {
-      "name": "Matt",
-      "teamLabel": "DELTA 8",
-      "lastYearRank": 8,
+      "name": "Will",
+      "teamLabel": "Just Win Baby",
+      "lastYearRank": 3,
       "picks": [
         {
           "week": 1,
-          "team": "Houston Texans",
-          "result": "L",
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:08:37.050Z",
-          "margin": -10
+          "team": "",
+          "result": null
         },
         {
           "week": 2,
@@ -228,29 +70,47 @@
           "result": null
         }
       ],
-      "eliminated": true,
-      "eliminatedWeek": 1,
+      "eliminated": false,
+      "marginOfVictory": 0
+    },
+    {
+      "name": "Ryan",
+      "teamLabel": "Quail Man SWAG",
+      "lastYearRank": 4,
+      "picks": [
+        {
+          "week": 1,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 2,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 3,
+          "team": "",
+          "result": null
+        }
+      ],
+      "eliminated": false,
       "marginOfVictory": 0
     },
     {
       "name": "Nick",
       "teamLabel": "Allen's Dirty Brown Kupp",
-      "lastYearRank": 9,
+      "lastYearRank": 5,
       "picks": [
         {
           "week": 1,
-          "team": "Las Vegas Raiders",
-          "result": "W",
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:06:09.857Z",
-          "margin": 0
+          "team": "",
+          "result": null
         },
         {
           "week": 2,
-          "team": "New England Patriots",
-          "result": null,
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:06:14.888Z"
+          "team": "",
+          "result": null
         },
         {
           "week": 3,
@@ -262,24 +122,19 @@
       "marginOfVictory": 0
     },
     {
-      "name": "William",
-      "teamLabel": "Just Win Baby",
-      "lastYearRank": 10,
+      "name": "Chris",
+      "teamLabel": "Hello Naber!",
+      "lastYearRank": 6,
       "picks": [
         {
           "week": 1,
-          "team": "Philadelphia Eagles",
-          "result": "W",
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:05:56.427Z",
-          "margin": 7
+          "team": "",
+          "result": null
         },
         {
           "week": 2,
-          "team": "New York Giants",
-          "result": null,
-          "manualResult": true,
-          "lastUpdated": "2025-08-14T14:05:51.392Z"
+          "team": "",
+          "result": null
         },
         {
           "week": 3,
@@ -288,168 +143,109 @@
         }
       ],
       "eliminated": false,
-      "marginOfVictory": 7
+      "marginOfVictory": 0
+    },
+    {
+      "name": "Josh",
+      "teamLabel": "S K",
+      "lastYearRank": 7,
+      "picks": [
+        {
+          "week": 1,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 2,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 3,
+          "team": "",
+          "result": null
+        }
+      ],
+      "eliminated": false,
+      "marginOfVictory": 0
+    },
+    {
+      "name": "Weston",
+      "teamLabel": "Robert DUUUVAL",
+      "lastYearRank": 8,
+      "picks": [
+        {
+          "week": 1,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 2,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 3,
+          "team": "",
+          "result": null
+        }
+      ],
+      "eliminated": false,
+      "marginOfVictory": 0
+    },
+    {
+      "name": "Matt",
+      "teamLabel": "DELTA 8",
+      "lastYearRank": 9,
+      "picks": [
+        {
+          "week": 1,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 2,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 3,
+          "team": "",
+          "result": null
+        }
+      ],
+      "eliminated": false,
+      "marginOfVictory": 0
+    },
+    {
+      "name": "Austin",
+      "teamLabel": "Honey Baked Lamb",
+      "lastYearRank": 10,
+      "picks": [
+        {
+          "week": 1,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 2,
+          "team": "",
+          "result": null
+        },
+        {
+          "week": 3,
+          "team": "",
+          "result": null
+        }
+      ],
+      "eliminated": false,
+      "marginOfVictory": 0
     }
   ],
   "gameResults": {
-    "week1": [
-      {
-        "date": "2025-08-07",
-        "matchup": "Indianapolis Colts at Baltimore Ravens",
-        "homeTeam": "Baltimore Ravens",
-        "awayTeam": "Indianapolis Colts",
-        "homeScore": 24,
-        "awayScore": 16,
-        "winner": "Baltimore Ravens"
-      },
-      {
-        "date": "2025-08-07",
-        "matchup": "Cincinnati Bengals at Philadelphia Eagles",
-        "homeTeam": "Philadelphia Eagles",
-        "awayTeam": "Cincinnati Bengals",
-        "homeScore": 34,
-        "awayScore": 27,
-        "winner": "Philadelphia Eagles"
-      },
-      {
-        "date": "2025-08-07",
-        "matchup": "Las Vegas Raiders at Seattle Seahawks",
-        "homeTeam": "Seattle Seahawks",
-        "awayTeam": "Las Vegas Raiders",
-        "homeScore": 23,
-        "awayScore": 23,
-        "winner": "Tie"
-      },
-      {
-        "date": "2025-08-08",
-        "matchup": "Cleveland Browns at Carolina Panthers",
-        "homeTeam": "Carolina Panthers",
-        "awayTeam": "Cleveland Browns",
-        "homeScore": 10,
-        "awayScore": 30,
-        "winner": "Cleveland Browns"
-      },
-      {
-        "date": "2025-08-08",
-        "matchup": "Detroit Lions at Atlanta Falcons",
-        "homeTeam": "Atlanta Falcons",
-        "awayTeam": "Detroit Lions",
-        "homeScore": 10,
-        "awayScore": 17,
-        "winner": "Detroit Lions",
-        "note": "Game ended early"
-      },
-      {
-        "date": "2025-08-08",
-        "matchup": "Washington Commanders at New England Patriots",
-        "homeTeam": "New England Patriots",
-        "awayTeam": "Washington Commanders",
-        "homeScore": 48,
-        "awayScore": 18,
-        "winner": "New England Patriots"
-      },
-      {
-        "date": "2025-08-09",
-        "matchup": "New York Giants at Buffalo Bills",
-        "homeTeam": "Buffalo Bills",
-        "awayTeam": "New York Giants",
-        "homeScore": 25,
-        "awayScore": 34,
-        "winner": "New York Giants"
-      },
-      {
-        "date": "2025-08-09",
-        "matchup": "Houston Texans at Minnesota Vikings",
-        "homeTeam": "Minnesota Vikings",
-        "awayTeam": "Houston Texans",
-        "homeScore": 20,
-        "awayScore": 10,
-        "winner": "Minnesota Vikings"
-      },
-      {
-        "date": "2025-08-09",
-        "matchup": "Pittsburgh Steelers at Jacksonville Jaguars",
-        "homeTeam": "Jacksonville Jaguars",
-        "awayTeam": "Pittsburgh Steelers",
-        "homeScore": 25,
-        "awayScore": 31,
-        "winner": "Pittsburgh Steelers"
-      },
-      {
-        "date": "2025-08-09",
-        "matchup": "Tennessee Titans at Tampa Bay Buccaneers",
-        "homeTeam": "Tampa Bay Buccaneers",
-        "awayTeam": "Tennessee Titans",
-        "homeScore": 29,
-        "awayScore": 7,
-        "winner": "Tampa Bay Buccaneers"
-      },
-      {
-        "date": "2025-08-09",
-        "matchup": "Kansas City Chiefs at Arizona Cardinals",
-        "homeTeam": "Arizona Cardinals",
-        "awayTeam": "Kansas City Chiefs",
-        "homeScore": 20,
-        "awayScore": 17,
-        "winner": "Arizona Cardinals"
-      },
-      {
-        "date": "2025-08-09",
-        "matchup": "New York Jets at Green Bay Packers",
-        "homeTeam": "Green Bay Packers",
-        "awayTeam": "New York Jets",
-        "homeScore": 10,
-        "awayScore": 30,
-        "winner": "New York Jets"
-      },
-      {
-        "date": "2025-08-09",
-        "matchup": "Denver Broncos at San Francisco 49ers",
-        "homeTeam": "San Francisco 49ers",
-        "awayTeam": "Denver Broncos",
-        "homeScore": 9,
-        "awayScore": 30,
-        "winner": "Denver Broncos"
-      },
-      {
-        "date": "2025-08-09",
-        "matchup": "Dallas Cowboys at Los Angeles Rams",
-        "homeTeam": "Los Angeles Rams",
-        "awayTeam": "Dallas Cowboys",
-        "homeScore": 31,
-        "awayScore": 21,
-        "winner": "Los Angeles Rams"
-      },
-      {
-        "date": "2025-08-10",
-        "matchup": "New Orleans Saints at Los Angeles Chargers",
-        "homeTeam": "Los Angeles Chargers",
-        "awayTeam": "New Orleans Saints",
-        "homeScore": 27,
-        "awayScore": 13,
-        "winner": "Los Angeles Chargers"
-      },
-      {
-        "date": "2025-08-10",
-        "matchup": "Miami Dolphins at Chicago Bears",
-        "homeTeam": "Chicago Bears",
-        "awayTeam": "Miami Dolphins",
-        "homeScore": 24,
-        "awayScore": 24,
-        "winner": "Tie"
-      }
-    ]
+    "week1": [],
+    "week2": [],
+    "week3": []
   },
-  "week2": [
-    {
-      "date": "2025-08-16",
-      "matchup": "Arizona Cardinals at Denver Broncos",
-      "homeTeam": "Denver Broncos",
-      "awayTeam": "Arizona Cardinals",
-      "homeScore": 27,
-      "awayScore": 7,
-      "winner": "Denver Broncos"
-    }
-  ],
-  "lastUpdated": "2025-08-17T12:22:20.000Z"
+  "lastUpdated": "2026-08-10T00:00:00.000Z"
 }

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>HowBoutIt Preseason Survivor Pool</title>
-  <meta name="description" content="NFL Preseason Survivor Pool — live picks, margins, and draft order.">
+  <title>2026 HowBoutIt Preseason Survivor Pool</title>
+  <meta name="description" content="2026 NFL Preseason Survivor Pool — live picks, margins, and draft order.">
   <meta name="theme-color" content="#6d28d9">
   <link rel="manifest" href="manifest.webmanifest">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
@@ -146,69 +146,72 @@
   <script type="text/babel">
     const { useState, useEffect, useRef, useMemo } = React;
     
-    // Preseason schedule used for reference
+    const SEASON_YEAR = 2026;
+    const isCurrentSeasonData = (data) => Number(data && data.season) === SEASON_YEAR;
+
+    // Official 2026 preseason schedule. The standalone Hall of Fame Game is not part of the pool.
     const preseasonSchedule = [
       {
         week: 1,
         games: [
-          { date: '2025-08-07', matchup: 'Indianapolis Colts at Baltimore Ravens', time: '7:00' },
-          { date: '2025-08-07', matchup: 'Cincinnati Bengals at Philadelphia Eagles', time: '7:30' },
-          { date: '2025-08-07', matchup: 'Las Vegas Raiders at Seattle Seahawks', time: '10:00' },
-          { date: '2025-08-08', matchup: 'Detroit Lions at Atlanta Falcons', time: '7:00' },
-          { date: '2025-08-08', matchup: 'Cleveland Browns at Carolina Panthers', time: '7:00' },
-          { date: '2025-08-08', matchup: 'Washington Commanders at New England Patriots', time: '7:30' },
-          { date: '2025-08-09', matchup: 'New York Giants at Buffalo Bills', time: '1:00' },
-          { date: '2025-08-09', matchup: 'Houston Texans at Minnesota Vikings', time: '4:00' },
-          { date: '2025-08-09', matchup: 'Pittsburgh Steelers at Jacksonville Jaguars', time: '7:00' },
-          { date: '2025-08-09', matchup: 'Dallas Cowboys at Los Angeles Rams', time: '7:00' },
-          { date: '2025-08-09', matchup: 'Tennessee Titans at Tampa Bay Buccaneers', time: '7:30' },
-          { date: '2025-08-09', matchup: 'Kansas City Chiefs at Arizona Cardinals', time: '8:00' },
-          { date: '2025-08-09', matchup: 'New York Jets at Green Bay Packers', time: '8:00' },
-          { date: '2025-08-09', matchup: 'Denver Broncos at San Francisco 49ers', time: '8:30' },
-          { date: '2025-08-10', matchup: 'Miami Dolphins at Chicago Bears', time: '1:00' },
-          { date: '2025-08-10', matchup: 'New Orleans Saints at Los Angeles Chargers', time: '4:05' },
+          { date: '2026-08-13', matchup: 'Detroit Lions at Cincinnati Bengals', time: '7:00 PM', kickoff: '2026-08-13T19:00:00-04:00' },
+          { date: '2026-08-13', matchup: 'Green Bay Packers at Pittsburgh Steelers', time: '7:00 PM', kickoff: '2026-08-13T19:00:00-04:00' },
+          { date: '2026-08-13', matchup: 'Indianapolis Colts at New England Patriots', time: '7:30 PM', kickoff: '2026-08-13T19:30:00-04:00' },
+          { date: '2026-08-13', matchup: 'Arizona Cardinals at Las Vegas Raiders', time: '8:00 PM', kickoff: '2026-08-13T20:00:00-04:00' },
+          { date: '2026-08-13', matchup: 'Los Angeles Chargers at Houston Texans', time: '8:00 PM', kickoff: '2026-08-13T20:00:00-04:00' },
+          { date: '2026-08-13', matchup: 'Tennessee Titans at San Francisco 49ers', time: '9:00 PM', kickoff: '2026-08-13T21:00:00-04:00' },
+          { date: '2026-08-14', matchup: 'Denver Broncos at Atlanta Falcons', time: '7:00 PM', kickoff: '2026-08-14T19:00:00-04:00' },
+          { date: '2026-08-14', matchup: 'Tampa Bay Buccaneers at New York Jets', time: '7:00 PM', kickoff: '2026-08-14T19:00:00-04:00' },
+          { date: '2026-08-14', matchup: 'Miami Dolphins at Washington Commanders', time: '7:00 PM', kickoff: '2026-08-14T19:00:00-04:00' },
+          { date: '2026-08-15', matchup: 'Carolina Panthers at Buffalo Bills', time: '1:00 PM', kickoff: '2026-08-15T13:00:00-04:00' },
+          { date: '2026-08-15', matchup: 'Cleveland Browns at Chicago Bears', time: '1:00 PM', kickoff: '2026-08-15T13:00:00-04:00' },
+          { date: '2026-08-15', matchup: 'Minnesota Vikings at New York Giants', time: '1:00 PM', kickoff: '2026-08-15T13:00:00-04:00' },
+          { date: '2026-08-15', matchup: 'Los Angeles Rams at Kansas City Chiefs', time: '4:00 PM', kickoff: '2026-08-15T16:00:00-04:00' },
+          { date: '2026-08-15', matchup: 'Jacksonville Jaguars at New Orleans Saints', time: '4:00 PM', kickoff: '2026-08-15T16:00:00-04:00' },
+          { date: '2026-08-15', matchup: 'Philadelphia Eagles at Baltimore Ravens', time: '7:00 PM', kickoff: '2026-08-15T19:00:00-04:00' },
+          { date: '2026-08-15', matchup: 'Dallas Cowboys at Seattle Seahawks', time: '8:00 PM', kickoff: '2026-08-15T20:00:00-04:00' },
         ]
       },
       {
         week: 2,
         games: [
-          { date: '2025-08-15', matchup: 'Tennessee Titans at Atlanta Falcons', time: '7:00' },
-          { date: '2025-08-15', matchup: 'Kansas City Chiefs at Seattle Seahawks', time: '10:00' },
-          { date: '2025-08-16', matchup: 'Miami Dolphins at Detroit Lions', time: '1:00' },
-          { date: '2025-08-16', matchup: 'Carolina Panthers at Houston Texans', time: '1:00' },
-          { date: '2025-08-16', matchup: 'Green Bay Packers at Indianapolis Colts', time: '1:00' },
-          { date: '2025-08-16', matchup: 'New England Patriots at Minnesota Vikings', time: '1:00' },
-          { date: '2025-08-16', matchup: 'Cleveland Browns at Philadelphia Eagles', time: '1:00' },
-          { date: '2025-08-16', matchup: 'San Francisco 49ers at Las Vegas Raiders', time: '4:00' },
-          { date: '2025-08-16', matchup: 'Baltimore Ravens at Dallas Cowboys', time: '7:00' },
-          { date: '2025-08-16', matchup: 'Los Angeles Chargers at Los Angeles Rams', time: '7:00' },
-          { date: '2025-08-16', matchup: 'New York Jets at New York Giants', time: '7:00' },
-          { date: '2025-08-16', matchup: 'Tampa Bay Buccaneers at Pittsburgh Steelers', time: '7:00' },
-          { date: '2025-08-16', matchup: 'Arizona Cardinals at Denver Broncos', time: '9:30' },
-          { date: '2025-08-17', matchup: 'Jacksonville Jaguars at New Orleans Saints', time: '1:00' },
-          { date: '2025-08-17', matchup: 'Buffalo Bills at Chicago Bears', time: '8:00' },
-          { date: '2025-08-18', matchup: 'Cincinnati Bengals at Washington Commanders', time: '8:00' },
+          { date: '2026-08-20', matchup: 'Las Vegas Raiders at Houston Texans', time: '8:00 PM', kickoff: '2026-08-20T20:00:00-04:00' },
+          { date: '2026-08-20', matchup: 'San Francisco 49ers at Los Angeles Chargers', time: '10:00 PM', kickoff: '2026-08-20T22:00:00-04:00' },
+          { date: '2026-08-21', matchup: 'New York Jets at Pittsburgh Steelers', time: '7:00 PM', kickoff: '2026-08-21T19:00:00-04:00' },
+          { date: '2026-08-21', matchup: 'Carolina Panthers at Jacksonville Jaguars', time: '7:30 PM', kickoff: '2026-08-21T19:30:00-04:00' },
+          { date: '2026-08-21', matchup: 'Green Bay Packers at Denver Broncos', time: '9:00 PM', kickoff: '2026-08-21T21:00:00-04:00' },
+          { date: '2026-08-22', matchup: 'Washington Commanders at Detroit Lions', time: '12:00 PM', kickoff: '2026-08-22T12:00:00-04:00' },
+          { date: '2026-08-22', matchup: 'Buffalo Bills at Cleveland Browns', time: '1:00 PM', kickoff: '2026-08-22T13:00:00-04:00' },
+          { date: '2026-08-22', matchup: 'Atlanta Falcons at Indianapolis Colts', time: '1:00 PM', kickoff: '2026-08-22T13:00:00-04:00' },
+          { date: '2026-08-22', matchup: 'Baltimore Ravens at Minnesota Vikings', time: '1:00 PM', kickoff: '2026-08-22T13:00:00-04:00' },
+          { date: '2026-08-22', matchup: 'New Orleans Saints at Los Angeles Rams', time: '4:00 PM', kickoff: '2026-08-22T16:00:00-04:00' },
+          { date: '2026-08-22', matchup: 'New York Giants at Miami Dolphins', time: '4:00 PM', kickoff: '2026-08-22T16:00:00-04:00' },
+          { date: '2026-08-22', matchup: 'Chicago Bears at Cincinnati Bengals', time: '7:00 PM', kickoff: '2026-08-22T19:00:00-04:00' },
+          { date: '2026-08-22', matchup: 'Philadelphia Eagles at New England Patriots', time: '7:00 PM', kickoff: '2026-08-22T19:00:00-04:00' },
+          { date: '2026-08-22', matchup: 'Kansas City Chiefs at Tampa Bay Buccaneers', time: '7:30 PM', kickoff: '2026-08-22T19:30:00-04:00' },
+          { date: '2026-08-22', matchup: 'Dallas Cowboys at Arizona Cardinals', time: '10:00 PM', kickoff: '2026-08-22T22:00:00-04:00' },
+          { date: '2026-08-23', matchup: 'Seattle Seahawks at Tennessee Titans', time: '8:00 PM', kickoff: '2026-08-23T20:00:00-04:00' },
         ]
       },
       {
         week: 3,
         games: [
-          { date: '2025-08-21', matchup: 'Pittsburgh Steelers at Carolina Panthers', time: '7:00' },
-          { date: '2025-08-21', matchup: 'New England Patriots at New York Giants', time: '8:00' },
-          { date: '2025-08-22', matchup: 'Philadelphia Eagles at New York Jets', time: '7:30' },
-          { date: '2025-08-22', matchup: 'Atlanta Falcons at Dallas Cowboys', time: '8:00' },
-          { date: '2025-08-22', matchup: 'Minnesota Vikings at Tennessee Titans', time: '8:00' },
-          { date: '2025-08-22', matchup: 'Chicago Bears at Kansas City Chiefs', time: '8:20' },
-          { date: '2025-08-23', matchup: 'Baltimore Ravens at Washington Commanders', time: '12:00' },
-          { date: '2025-08-23', matchup: 'Indianapolis Colts at Cincinnati Bengals', time: '1:00' },
-          { date: '2025-08-23', matchup: 'Los Angeles Rams at Cleveland Browns', time: '1:00' },
-          { date: '2025-08-23', matchup: 'Houston Texans at Detroit Lions', time: '1:00' },
-          { date: '2025-08-23', matchup: 'Denver Broncos at New Orleans Saints', time: '1:00' },
-          { date: '2025-08-23', matchup: 'Seattle Seahawks at Green Bay Packers', time: '4:00' },
-          { date: '2025-08-23', matchup: 'Jacksonville Jaguars at Miami Dolphins', time: '7:00' },
-          { date: '2025-08-23', matchup: 'Buffalo Bills at Tampa Bay Buccaneers', time: '7:30' },
-          { date: '2025-08-23', matchup: 'Los Angeles Chargers at San Francisco 49ers', time: '8:30' },
-          { date: '2025-08-23', matchup: 'Las Vegas Raiders at Arizona Cardinals', time: '10:00' },
+          { date: '2026-08-27', matchup: 'Pittsburgh Steelers at Buffalo Bills', time: '7:00 PM', kickoff: '2026-08-27T19:00:00-04:00' },
+          { date: '2026-08-27', matchup: 'New England Patriots at Cleveland Browns', time: '8:00 PM', kickoff: '2026-08-27T20:00:00-04:00' },
+          { date: '2026-08-27', matchup: 'San Francisco 49ers at Las Vegas Raiders', time: '8:00 PM', kickoff: '2026-08-27T20:00:00-04:00' },
+          { date: '2026-08-27', matchup: 'Los Angeles Rams at Los Angeles Chargers', time: '10:00 PM', kickoff: '2026-08-27T22:00:00-04:00' },
+          { date: '2026-08-28', matchup: 'Washington Commanders at Baltimore Ravens', time: '6:00 PM', kickoff: '2026-08-28T18:00:00-04:00' },
+          { date: '2026-08-28', matchup: 'Houston Texans at Carolina Panthers', time: '7:00 PM', kickoff: '2026-08-28T19:00:00-04:00' },
+          { date: '2026-08-28', matchup: 'Atlanta Falcons at Miami Dolphins', time: '7:00 PM', kickoff: '2026-08-28T19:00:00-04:00' },
+          { date: '2026-08-28', matchup: 'Tampa Bay Buccaneers at Jacksonville Jaguars', time: '7:30 PM', kickoff: '2026-08-28T19:30:00-04:00' },
+          { date: '2026-08-28', matchup: 'New York Giants at New York Jets', time: '7:30 PM', kickoff: '2026-08-28T19:30:00-04:00' },
+          { date: '2026-08-28', matchup: 'New Orleans Saints at Dallas Cowboys', time: '8:00 PM', kickoff: '2026-08-28T20:00:00-04:00' },
+          { date: '2026-08-28', matchup: 'Seattle Seahawks at Kansas City Chiefs', time: '8:00 PM', kickoff: '2026-08-28T20:00:00-04:00' },
+          { date: '2026-08-28', matchup: 'Cincinnati Bengals at Philadelphia Eagles', time: '8:00 PM', kickoff: '2026-08-28T20:00:00-04:00' },
+          { date: '2026-08-28', matchup: 'Arizona Cardinals at Green Bay Packers', time: '8:00 PM', kickoff: '2026-08-28T20:00:00-04:00' },
+          { date: '2026-08-28', matchup: 'Minnesota Vikings at Denver Broncos', time: '9:00 PM', kickoff: '2026-08-28T21:00:00-04:00' },
+          { date: '2026-08-29', matchup: 'Detroit Lions at Indianapolis Colts', time: '1:00 PM', kickoff: '2026-08-29T13:00:00-04:00' },
+          { date: '2026-08-29', matchup: 'Chicago Bears at Tennessee Titans', time: '6:00 PM', kickoff: '2026-08-29T18:00:00-04:00' },
         ]
       }
     ];
@@ -235,6 +238,7 @@
       // Public auto-persist controls
       const [autoPersist, setAutoPersist] = useState(localStorage.getItem('autoPersistEnabled') === 'true');
       const [gistIdState, setGistIdState] = useState((localStorage.getItem('gistId') || '').trim());
+      const [gistSeasonReady, setGistSeasonReady] = useState(false);
       const saveDebounceRef = useRef(null);
       const lastSavedHashRef = useRef('');
       // Keep a synchronous reference to gistId to avoid async state timing issues
@@ -242,7 +246,7 @@
       // Feature flags and Fantasy ADP state
       const [features, setFeatures] = useState({
         showFantasyADP: false,
-        adp: { scoring: 'ppr', teams: 10, year: 2025, topN: 100 }
+        adp: { scoring: 'ppr', teams: 10, year: SEASON_YEAR, topN: 100 }
       });
       const [fantasyADP, setFantasyADP] = useState([]);
       const [adpLoading, setAdpLoading] = useState(false);
@@ -480,9 +484,9 @@
         "Ryan (Quail Man SWAG) — Ryan, ‘Quail Man SWAG’? Bro, you’re reppin’ a deep-cut Doug Funnie reference like it’s 1996. Your team’s got the swag of a kid who brought a Capri Sun to prom. Bet you’re startin’ a backup RB who fumbles more than a drunk uncle at Thanksgiving.",
         "Weston (Robert DUUUVAL) — Weston, you’re ridin’ for Jacksonville harder than a guy with a mullet and a Natty Light tattoo. Bet you’re prayin’ to the ghost of Blake Bortles to save your season.",
         "Jordan (GRAVEDIGGER) — Jordan, the only thing you’re buryin’ is your playoff hopes. Your roster’s more like a 53-year-old accountant named Randy who pulled a hammy playin’ pickleball.",
-        "John (DELTA 8) — John, you sound like you drafted after hittin’ a gas-station vape. Your lineup’s got more gummies than touchdowns. Your WR1 retired in 2017 and you didn’t notice.",
+        "Matt (DELTA 8) — Matt, you sound like you drafted after hittin’ a gas-station vape. Your lineup’s got more gummies than touchdowns. Your WR1 retired in 2017 and you didn’t notice.",
         "Nick (Allen’s Dirty Brown Kupp) — Nick, that name’s so filthy it gets flagged on Craigslist. You’re bankin’ on Cooper Kupp while your WR2 sells bootleg jerseys in Lot B.",
-        "William (Just Win Baby) — William, more like ‘Just Lose, Maybe.’ You’re quotin’ Al Davis while your QB throws four picks. Just win? Try just survivin’ the group chat roast."
+        "Will (Just Win Baby) — Will, more like ‘Just Lose, Maybe.’ You’re quotin’ Al Davis while your QB throws four picks. Just win? Try just survivin’ the group chat roast."
       ], []);
       // Build continuous stream (initially in given order); click will reshuffle
       const [streamJokes, setStreamJokes] = useState([]);
@@ -596,6 +600,7 @@
       // Function to load data with cache-busting (prefers Gist via config.json)
       const loadData = async () => {
         setRefreshing(true);
+        setGistSeasonReady(false);
         const timestamp = new Date().getTime();
         // Try to read gistId from config.json
         let gistId = '';
@@ -652,21 +657,34 @@
             const res = await fetch(`${dataFile.raw_url}?t=${timestamp}`);
             if (!res.ok) throw new Error(`Gist raw fetch failed: ${res.status}`);
             const data = await res.json();
+            if (!isCurrentSeasonData(data)) {
+              const mismatchError = new Error(`Ignoring non-${SEASON_YEAR} Gist data`);
+              mismatchError.code = 'season_mismatch';
+              throw mismatchError;
+            }
             setManagers(data.managers || []);
             setGameResults(data.gameResults || {});
             setLastUpdated(data.lastUpdated || '');
+            setGistSeasonReady(true);
             setLoading(false);
             setRefreshing(false);
             await fetchADPIfEnabled(cfgFeatures);
             return;
           } catch (err) {
-            console.error('Gist load failed, falling back to local data.json:', err);
+            if (err && err.code === 'season_mismatch') {
+              console.info(`[Data] ${SEASON_YEAR} pool is using repository starter data until the Gist is rolled forward.`);
+            } else {
+              console.error('Gist load failed, falling back to local data.json:', err);
+            }
           }
         }
         // Fallback to local data.json
         try {
           const response = await fetch(`data.json?t=${timestamp}`);
           const data = await response.json();
+          if (!isCurrentSeasonData(data)) {
+            throw new Error(`Local data.json is not configured for ${SEASON_YEAR}`);
+          }
           setManagers(data.managers || []);
           setGameResults(data.gameResults || {});
           setLastUpdated(data.lastUpdated || '');
@@ -707,7 +725,11 @@
         let cancelled = false;
         async function fetchScores() {
           try {
-            const res = await fetchWithRetry('https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard', {}, 5, 1000, 2);
+            // ESPN numbers the Hall of Fame window as preseason week 1, so pool weeks 1-3 map to ESPN weeks 2-4.
+            const { activeWeek } = computeCalendarState(preseasonSchedule);
+            const espnWeek = Math.min(4, Math.max(2, Number(activeWeek) + 1));
+            const scoreboardUrl = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard?dates=${SEASON_YEAR}&seasontype=1&week=${espnWeek}&limit=100`;
+            const res = await fetchWithRetry(scoreboardUrl, {}, 5, 1000, 2);
             const data = await res.json();
             if (!cancelled) {
               setGames(data.events || []);
@@ -911,10 +933,8 @@
           return away === teamName || home === teamName;
         });
         if (!g) return false;
-        // Assume ET in August (DST -04:00). Times provided without am/pm are typical PM kickoff; treat as local ET clock time.
-        // Construct an ET-like timestamp explicitly.
-        const timeStr = (g.time || '00:00').padStart(5, '0');
-        const dt = new Date(`${g.date}T${timeStr}:00-04:00`);
+        // Prefer the explicit ET kickoff so afternoon games never lock at 1 a.m. by mistake.
+        const dt = g.kickoff ? new Date(g.kickoff) : new Date(`${g.date}T23:59:59-04:00`);
         return Date.now() >= dt.getTime();
       };
 
@@ -1148,11 +1168,16 @@
 
       // Debounced auto-persist when managers change and toggle is enabled
       useEffect(() => {
-        if (!autoPersist) return;
+        if (!autoPersist || !gistSeasonReady) return;
         const id = (gistIdState || localStorage.getItem('gistId') || '').trim();
         const token = (localStorage.getItem('gistToken') || '').trim();
         if (!id || !token) return;
-        const payloadObj = { managers, lastUpdated: new Date().toISOString() };
+        const payloadObj = {
+          season: SEASON_YEAR,
+          managers,
+          gameResults,
+          lastUpdated: new Date().toISOString()
+        };
         const payloadStr = JSON.stringify(payloadObj, null, 2);
         if (lastSavedHashRef.current === payloadStr) return;
         if (saveDebounceRef.current) clearTimeout(saveDebounceRef.current);
@@ -1166,7 +1191,7 @@
             saveDebounceRef.current = null;
           }
         };
-      }, [managers, autoPersist, gistIdState]);
+      }, [managers, gameResults, autoPersist, gistIdState, gistSeasonReady]);
       // Initialize mobile/desktop defaults for expansions and chart section ONCE after data loads
       useEffect(() => {
         if (initViewApplied.current) return;
@@ -1504,11 +1529,15 @@
                 )}
               </div>
               <div className="flex items-center gap-3">
-                <label className="hidden sm:flex items-center gap-2 text-xs select-none" title="Automatically save live results to your configured Gist">
+                <label
+                  className={`hidden sm:flex items-center gap-2 text-xs select-none ${gistSeasonReady ? '' : 'opacity-60'}`}
+                  title={gistSeasonReady ? 'Automatically save live results to your configured Gist' : `Initialize the ${SEASON_YEAR} Gist from the admin page first`}
+                >
                   <input
                     type="checkbox"
                     checked={autoPersist}
                     onChange={(e) => setAutoPersist(e.target.checked)}
+                    disabled={!gistSeasonReady}
                     aria-label="Enable auto-save to Gist"
                     className="h-4 w-4 rounded border-purple-400 bg-transparent"
                   />
@@ -1567,7 +1596,7 @@
           <header className="text-center py-6 animate-fade-in">
             <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold flex items-center justify-center gap-3 drop-shadow-lg">
               <span className="animate-trophy">🏆</span>
-              HowBoutIt Preseason Survivor Pool
+              {SEASON_YEAR} HowBoutIt Preseason Survivor Pool
             </h1>
             <p className="mt-2 text-base sm:text-lg md:text-xl">Who is going to get the #1 Fucking Pick?!</p>
             <div className="mt-2 text-xs text-purple-200">
@@ -1952,7 +1981,7 @@
           {/* Preseason Schedule */}
           <section className="glass rounded-2xl p-5 overflow-auto animate-fade-in">
             <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
-              <i className="fas fa-calendar-alt"></i> Preseason Schedule (Weeks 1–3)
+              <i className="fas fa-calendar-alt"></i> {SEASON_YEAR} Preseason Schedule (Weeks 1–3)
             </h2>
             {/* Desktop table */}
             <div className="hidden md:block overflow-x-auto">
@@ -2400,7 +2429,7 @@
 
           {/* Footer */}
           <footer className="text-center py-6 text-sm text-purple-300 border-t border-white/10">
-            <p>NFL Preseason Survivor Pool • Draft order determined by survival and margin of victory</p>
+            <p>{SEASON_YEAR} NFL Preseason Survivor Pool • Draft order determined by survival and margin of victory</p>
             <p className="mt-1">Admin: <a href="admin.html" className="text-purple-200 hover:text-white">Manage Pool</a></p>
           </footer>
         </div>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "NFL Preseason Survivor Pool",
-  "short_name": "Survivor Pool",
-  "description": "Track your league's preseason picks, wins, margins and draft order.",
+  "name": "2026 NFL Preseason Survivor Pool",
+  "short_name": "2026 Survivor Pool",
+  "description": "Track your league's 2026 preseason picks, wins, margins and draft order.",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#1f1147",

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Minimal service worker for installability and basic offline support */
-const CACHE_NAME = 'survivor-pool-v1-20250819a';
+const CACHE_NAME = 'survivor-pool-v2-20260810';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## What changed

- updates the public and admin pages for the 2026 NFL preseason
- loads the official three-week, 48-game schedule with explicit kickoff times
- resets the ten-manager pool and preserves the final 2025 data archive
- gates Gist data by season so stale 2025 data cannot overwrite the 2026 starter state
- refreshes the app manifest, service worker cache, configuration, and documentation

## Why

The site was still configured for the 2025 fantasy draft-order pool. This prepares it for the upcoming 2026 preseason while retaining last season's results.

## Validation

- confirmed current branch matched `origin/main` before branching
- parsed all JSON configuration and data files
- verified season values and the 2025 archive
- verified ten managers with three picks each
- verified all 48 scheduled preseason games
- ran `git diff --check`