### PR TITLE
Update 2026 roster and jokes

### DIFF
--- a/data.json
+++ b/data.json
@@ -4,7 +4,7 @@
     {
       "name": "Kevin",
       "teamLabel": "Check My Balls",
-      "lastYearRank": 1,
+      "lastYearRank": 7,
       "picks": [
         {
           "week": 1,
@@ -50,9 +50,9 @@
       "marginOfVictory": 0
     },
     {
-      "name": "Will",
-      "teamLabel": "Just Win Baby",
-      "lastYearRank": 3,
+      "name": "Michael",
+      "teamLabel": "The Sacks Kingdom",
+      "lastYearRank": 8,
       "picks": [
         {
           "week": 1,
@@ -76,7 +76,7 @@
     {
       "name": "Ryan",
       "teamLabel": "Quail Man SWAG",
-      "lastYearRank": 4,
+      "lastYearRank": 9,
       "picks": [
         {
           "week": 1,
@@ -100,7 +100,7 @@
     {
       "name": "Nick",
       "teamLabel": "Allen's Dirty Brown Kupp",
-      "lastYearRank": 5,
+      "lastYearRank": 10,
       "picks": [
         {
           "week": 1,
@@ -124,7 +124,7 @@
     {
       "name": "Chris",
       "teamLabel": "Hello Naber!",
-      "lastYearRank": 6,
+      "lastYearRank": 4,
       "picks": [
         {
           "week": 1,
@@ -148,7 +148,7 @@
     {
       "name": "Josh",
       "teamLabel": "S K",
-      "lastYearRank": 7,
+      "lastYearRank": 3,
       "picks": [
         {
           "week": 1,
@@ -172,7 +172,7 @@
     {
       "name": "Weston",
       "teamLabel": "Robert DUUUVAL",
-      "lastYearRank": 8,
+      "lastYearRank": 1,
       "picks": [
         {
           "week": 1,
@@ -196,7 +196,7 @@
     {
       "name": "Matt",
       "teamLabel": "DELTA 8",
-      "lastYearRank": 9,
+      "lastYearRank": 6,
       "picks": [
         {
           "week": 1,
@@ -220,7 +220,7 @@
     {
       "name": "Austin",
       "teamLabel": "Honey Baked Lamb",
-      "lastYearRank": 10,
+      "lastYearRank": 5,
       "picks": [
         {
           "week": 1,
@@ -247,5 +247,5 @@
     "week2": [],
     "week3": []
   },
-  "lastUpdated": "2026-08-10T00:00:00.000Z"
+  "lastUpdated": "2026-08-12T19:13:54.228Z"
 }

--- a/index.html
+++ b/index.html
@@ -477,16 +477,16 @@
       const tickerTrackRef = useRef(null);
       const [tickerDuration, setTickerDuration] = useState(20); // seconds
       const jokes = useMemo(() => [
-        "Chris (Hello Naber!) — Yo, Chris, 'Hello Naber'? Sounds like you’re tryin’ to flirt with the neighbor’s dog at the BBQ. Like, ‘Hey, Rover, you lookin’ fine in that flea collar, wanna split a Milk-Bone?’ Man, your team’s so soft, it’s like you drafted a roster full of participation trophies and vibes. Bet you’re startin’ a punter in Week 1, yellin’ ‘NABER!’ when he shanks it into the stands.",
-        "Josh (S K) — Josh, what’s ‘S K’ stand for? Shitty Kickers? You out here draftin’ guys who miss 20-yard field goals like they’re blindfolded at a carnival game. I bet your team’s game plan is just ‘vibe and cry.’ You’re the dude who shows up to the draft with a Ouija board, tryna summon Tom Brady’s ghost, but all you get is a spectral fumble from Jake Delhomme.",
-        "Kevin (Check My Balls) — Kevin, bro, ‘Check My Balls’? You sound like you’re one bad physical away from a malpractice lawsuit. Your team’s probably got more injuries than a Civil War reenactment gone wrong. Like, ‘Yo, doc, check my balls, I think I pulled something carryin’ this L.’ Bet you’re startin’ a third-string tight end who moonlights as an Uber driver. Keep it classy, Kev.",
-        "Austin (Honey Baked Lamb) — Austin, ‘Honey Baked Lamb’? What is this, a fantasy team or a hipster butcher shop? You out here servin’ artisanal losses with a side of kale. Bet your draft board’s just a charcuterie spread with Aaron Rodgers’ face carved in prosciutto.",
-        "Ryan (Quail Man SWAG) — Ryan, ‘Quail Man SWAG’? Bro, you’re reppin’ a deep-cut Doug Funnie reference like it’s 1996. Your team’s got the swag of a kid who brought a Capri Sun to prom. Bet you’re startin’ a backup RB who fumbles more than a drunk uncle at Thanksgiving.",
-        "Weston (Robert DUUUVAL) — Weston, you’re ridin’ for Jacksonville harder than a guy with a mullet and a Natty Light tattoo. Bet you’re prayin’ to the ghost of Blake Bortles to save your season.",
-        "Jordan (GRAVEDIGGER) — Jordan, the only thing you’re buryin’ is your playoff hopes. Your roster’s more like a 53-year-old accountant named Randy who pulled a hammy playin’ pickleball.",
-        "Matt (DELTA 8) — Matt, you sound like you drafted after hittin’ a gas-station vape. Your lineup’s got more gummies than touchdowns. Your WR1 retired in 2017 and you didn’t notice.",
-        "Nick (Allen’s Dirty Brown Kupp) — Nick, that name’s so filthy it gets flagged on Craigslist. You’re bankin’ on Cooper Kupp while your WR2 sells bootleg jerseys in Lot B.",
-        "Will (Just Win Baby) — Will, more like ‘Just Lose, Maybe.’ You’re quotin’ Al Davis while your QB throws four picks. Just win? Try just survivin’ the group chat roast."
+        "Kevin (Check My Balls) — Kevin named the team Check My Balls, which is a lot of confidence for a roster with no visible toughness. Every Sunday he opens the injury report like WebMD: already convinced something is swollen and somehow blaming the commissioner.",
+        "Jordan (GRAVEDIGGER) — GRAVEDIGGER sounds terrifying until you realize the graves are for players Jordan drafted two rounds early. He doesn’t bury opponents; he holds a tasteful little service for his projections every Monday.",
+        "Michael (The Sacks Kingdom) — Michael replaced Will and immediately founded The Sacks Kingdom. Buddy, that’s not a dynasty—it’s a medieval Hooters with worse pass protection and a Burger King crown.",
+        "Ryan (Quail Man SWAG) — Quail Man SWAG is the only team name wearing tighty-whities over khakis. Ryan’s draft strategy is pure Nickelodeon: loud colors, no adult supervision, cancelled before the playoffs.",
+        "Nick (Allen’s Dirty Brown Kupp) — Nick’s team name sounds less like fantasy football and more like evidence being sealed in a plastic bag. Even autocorrect looked at it and said, ‘Nope, I’m not getting subpoenaed.’",
+        "Chris (Hello Naber!) — Hello Naber! has the energy of a dad learning one rookie’s name and yelling it across Costco. Chris says ‘sleeper’ like he discovered fire, then drafts the guy everybody ranked 14th.",
+        "Josh (S K) — Josh enters as S K: two mysterious initials and zero available explanations. It’s like a government agency, except the intelligence failure happens in Round 1.",
+        "Weston (Robert DUUUVAL) — Robert DUUUVAL is ten percent wordplay and ninety percent Jacksonville mating call. Say DUUUVAL three times and a man in jorts appears to explain why this is finally the Jaguars’ year.",
+        "Matt (DELTA 8) — Matt calls the team DELTA 8 because REGULAR CONFIDENCE was already taken. By pick five he’s staring at the draft board like it just asked him to operate heavy machinery.",
+        "Austin (Honey Baked Lamb) — Honey Baked Lamb sounds like Easter dinner made by a man who lost the recipe and blamed the oven. Austin’s roster is the same: smells promising, looks expensive, and somebody’s apologizing by halftime."
       ], []);
       // Build continuous stream (initially in given order); click will reshuffle
       const [streamJokes, setStreamJokes] = useState([]);

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Minimal service worker for installability and basic offline support */
-const CACHE_NAME = 'survivor-pool-v2-20260810';
+const CACHE_NAME = 'survivor-pool-v2-20260812';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## What changed

- replaces Will with Michael in the 2026 starter roster
- sets Michael's team name to **The Sacks Kingdom**
- applies the manager rankings supplied for the 2026 pool
- replaces all ten ticker jokes with a completely new original roast set
- bumps the service-worker cache so returning browsers receive the update

## Why

The league roster and ranking order changed for the 2026 season, and the joke ticker needed a fresh set for this year's pool.

## Validation

- parsed and validated `data.json`
- matched all ten names, team labels, rankings, and the supplied timestamp
- confirmed each manager has three preseason picks
- confirmed exactly ten refreshed jokes
- confirmed the old Will/Just Win Baby joke is gone
- ran `git diff --check`