### PR TITLE
Harden site for league launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Single-page React app (vanilla React via `<script>` in `index.html`) hosted on G
 ## 2026 Season
 
 - The active pool covers official preseason Weeks 1-3, August 13-29, 2026. The standalone Hall of Fame Game is excluded.
-- `data.json` is reset for the ten returning managers. Their `lastYearRank` values are the final 2025 pool order and serve as the last tiebreaker.
+- `data.json` contains the ten 2026 managers. Their unique `lastYearRank` values (1 is best) are the agreed 2025 tiebreak order.
 - The final 2025 Gist snapshot is preserved in `data-2025.json`.
 - Active data must contain `"season": 2026`. Until the configured Gist is updated for 2026, both pages ignore its 2025 data and safely use the repository's starter `data.json`.
 - After deployment, open `admin.html` and use **Save to Gist** once to initialize the Gist for 2026. Gist revision history preserves the prior version as an additional backup.
@@ -26,8 +26,9 @@ Single-page React app (vanilla React via `<script>` in `index.html`) hosted on G
 ## Data and Persistence
 
 - Public reads use the configured GitHub Gist only when it matches the active season; otherwise they fall back to `data.json`.
-- Admin writes require a Gist token stored in the browser. This client-side setup is acceptable for this private league tool but should not be treated as secure.
-- Optional public auto-persist includes the season, managers, game results, and update timestamp. It remains disabled until the Gist already contains 2026 data.
+- The public site is strictly read-only. It never stores a GitHub token and cannot write to the Gist.
+- Admin writes require a short-lived Gist-only token. The token is kept only in the open admin tab, is never written to `localStorage`, and is cleared after a successful save.
+- The admin validates unique manager names, unique tiebreak ranks from 1 through the manager count, and duplicate team picks before saving.
 - Fantasy ADP is configured for 2026 in `config.json`.
 
 ## Local Development
@@ -39,10 +40,11 @@ Single-page React app (vanilla React via `<script>` in `index.html`) hosted on G
 
 Browser state:
 
-- `localStorage.gistId` and `localStorage.gistToken` configure Gist saves.
-- `localStorage.autoPersistEnabled` toggles automatic live-result saves.
+- `localStorage.gistId` stores the non-secret Gist identifier.
 - `localStorage.mutedAudio` persists the global mute setting.
 - The default admin password for a new browser is `survivor2026`; change it after first login.
+
+The admin password is a local convenience lock, not server-side authentication. The GitHub token is the write credential and should be narrowly scoped, short-lived, and revoked after the pool ends.
 
 ## Notes
 

--- a/admin.html
+++ b/admin.html
@@ -3,20 +3,20 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow, noarchive">
   <title>2026 Admin Panel - NFL Survivor Pool</title>
-  <!-- Tailwind CSS via Play CDN for rapid styling -->
+  <!-- Version-pinned CDN assets with integrity checks. -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <!-- React and ReactDOM -->
-  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" integrity="sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1" crossorigin="anonymous"></script>
   <!-- Babel Standalone enables JSX in the browser -->
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.28.5/babel.min.js" integrity="sha384-mP9sW+eK08VvAmlxEkn9Kn6egvKFtnFEfW7/u9feUWAIoTvnYAzT4NwsskP+uWUd" crossorigin="anonymous"></script>
   <!-- Font Awesome for icons -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
   <!-- Ajv for JSON Schema validation -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.17.1/ajv7.bundle.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.17.1/ajv7.bundle.min.js" integrity="sha384-jcZuBwUEZ1r+ExnGT1U2RKoTYhFvRYDAgO5ygTRwiirVTHAh9zS50vkEpBa6FfEX" crossorigin="anonymous"></script>
   <!-- diff for computing text diffs (line-by-line) -->
-  <script src="https://cdn.jsdelivr.net/npm/diff@5/dist/diff.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/diff@5.2.0/dist/diff.min.js" integrity="sha384-lJJVaUgxmk/PVfQnAsGN1QuJZrE+n6bg2EMu33yVZOJ2av/3UzTHbmnPCI7ENJYa" crossorigin="anonymous"></script>
   <style>
     body {
       background-image: linear-gradient(to top right, #3730a3, #6d28d9);
@@ -122,7 +122,9 @@
       // Gist persistence settings
       const [showSettings, setShowSettings] = useState(false);
       const [gistId, setGistId] = useState((localStorage.getItem('gistId') || '').trim());
-      const [gistToken, setGistToken] = useState((localStorage.getItem('gistToken') || '').trim());
+      // The token is intentionally session-only and is cleared after each save.
+      const [gistToken, setGistToken] = useState('');
+      const [dataSource, setDataSource] = useState('loading');
       const [isSaving, setIsSaving] = useState(false);
       const [dirty, setDirty] = useState(false);
       // Save preview & validation state
@@ -135,12 +137,24 @@
       
       // Check password on load
       useEffect(() => {
+        // Clean up credentials stored by older builds. Tokens must never persist in browser storage.
+        localStorage.removeItem('gistToken');
         const storedAuth = localStorage.getItem('adminAuthenticated');
         if (storedAuth === 'true') {
           setAuthenticated(true);
           loadData();
         }
       }, []);
+
+      useEffect(() => {
+        const warnOnUnsavedChanges = (event) => {
+          if (!dirty) return;
+          event.preventDefault();
+          event.returnValue = '';
+        };
+        window.addEventListener('beforeunload', warnOnUnsavedChanges);
+        return () => window.removeEventListener('beforeunload', warnOnUnsavedChanges);
+      }, [dirty]);
 
       // If no gistId (or whitespace) in localStorage/state, try to default from config.json
       useEffect(() => {
@@ -176,7 +190,7 @@
               properties: {
                 name: { type: 'string' },
                 teamLabel: { type: 'string' },
-                lastYearRank: { type: 'integer' },
+                lastYearRank: { type: 'integer', minimum: 1 },
                 eliminated: { type: 'boolean' },
                 buyback: { type: 'boolean' },
                 carryMargin: { type: ['number', 'integer'] },
@@ -204,6 +218,47 @@
         }
       };
 
+      const validatePoolRules = (data) => {
+        const errors = [];
+        const poolManagers = Array.isArray(data && data.managers) ? data.managers : [];
+        const rankOwners = new Map();
+        const nameOwners = new Map();
+
+        poolManagers.forEach((manager, index) => {
+          const name = String(manager && manager.name || '').trim();
+          const rank = Number(manager && manager.lastYearRank);
+          if (!name) {
+            errors.push({ instancePath: `/managers/${index}/name`, message: 'must not be blank' });
+          } else {
+            const key = name.toLowerCase();
+            if (nameOwners.has(key)) {
+              errors.push({ instancePath: `/managers/${index}/name`, message: `duplicates manager ${nameOwners.get(key)}` });
+            }
+            nameOwners.set(key, name);
+          }
+
+          if (!Number.isInteger(rank) || rank < 1 || rank > poolManagers.length) {
+            errors.push({ instancePath: `/managers/${index}/lastYearRank`, message: `must be a whole number from 1 to ${poolManagers.length}` });
+          } else if (rankOwners.has(rank)) {
+            errors.push({ instancePath: `/managers/${index}/lastYearRank`, message: `duplicates rank ${rank} used by ${rankOwners.get(rank)}` });
+          } else {
+            rankOwners.set(rank, name || `manager ${index + 1}`);
+          }
+
+          const usedTeams = new Set();
+          (Array.isArray(manager && manager.picks) ? manager.picks : []).forEach((pick, pickIndex) => {
+            const team = String(pick && pick.team || '').trim();
+            if (!team) return;
+            if (usedTeams.has(team)) {
+              errors.push({ instancePath: `/managers/${index}/picks/${pickIndex}/team`, message: `reuses ${team} in another week` });
+            }
+            usedTeams.add(team);
+          });
+        });
+
+        return errors;
+      };
+
       const getDataToSave = () => ({
         ...completeData,
         season: SEASON_YEAR,
@@ -212,22 +267,35 @@
       });
 
       const validateAgainstSchema = (data) => {
+        const poolRuleErrors = validatePoolRules(data);
         if (!window.ajv7) {
-          console.warn('Ajv not loaded; skipping validation');
-          return { valid: true, errors: [] };
+          console.error('Ajv not loaded; blocking validation');
+          return {
+            valid: false,
+            errors: [{ instancePath: 'data', message: 'validation library unavailable; reload the page before saving' }, ...poolRuleErrors]
+          };
         }
         try {
           const ajv = new window.ajv7({ allErrors: true, strict: false });
           const validate = ajv.compile(jsonSchema);
           const valid = validate(data);
-          return { valid: !!valid, errors: validate.errors || [] };
+          const errors = [...(validate.errors || []), ...poolRuleErrors];
+          return { valid: !!valid && errors.length === 0, errors };
         } catch (e) {
           console.error('Validation setup failed:', e);
-          return { valid: true, errors: [] };
+          return {
+            valid: false,
+            errors: [{ instancePath: 'data', message: 'validation could not run; reload the page before saving' }, ...poolRuleErrors]
+          };
         }
       };
 
       const startSaveFlow = async () => {
+        if (!(gistId || '').trim() || !(gistToken || '').trim()) {
+          setShowSettings(true);
+          showNotification('Enter the Gist ID and a session-only token before saving', 'error');
+          return;
+        }
         // Validate and prepare diff preview before confirming save
         const dataToSave = getDataToSave();
         const validation = validateAgainstSchema(dataToSave);
@@ -296,6 +364,7 @@
       
       const loadData = async () => {
         let ignoredPriorSeasonGist = false;
+        setDataSource('loading');
         // Try Gist first if configured; otherwise fall back to local data.json
         if (gistId) {
           try {
@@ -317,6 +386,7 @@
             setCompleteData(data);
             setJsonData(JSON.stringify(data, null, 2));
             setBaselineJson(JSON.stringify(data, null, 2));
+            setDataSource('gist');
             setDirty(false);
             return;
           } catch (err) {
@@ -337,12 +407,14 @@
           setCompleteData(data);
           setJsonData(JSON.stringify(data, null, 2));
           setBaselineJson(JSON.stringify(data, null, 2));
+          setDataSource('repository');
           setDirty(false);
           if (ignoredPriorSeasonGist) {
             showNotification(`Loaded ${SEASON_YEAR} starter data; last season's Gist was left untouched`, 'success');
           }
         } catch (error) {
           console.error('Error loading local data.json:', error);
+          setDataSource('error');
           showNotification('Error loading data', 'error');
         }
       };
@@ -469,6 +541,11 @@
           if (!isCurrentSeasonData(data)) {
             throw new Error(`Import must contain season: ${SEASON_YEAR}`);
           }
+          const validation = validateAgainstSchema(data);
+          if (!validation.valid) {
+            const detail = (validation.errors || []).map(err => `${err.instancePath || 'data'} ${err.message}`).join('; ');
+            throw new Error(`Import validation failed: ${detail}`);
+          }
           // Preserve entire structure (e.g., gameResults) and reflect it in state
           const importedManagers = Array.isArray(data.managers) ? data.managers : [];
           setManagers(importedManagers);
@@ -490,9 +567,8 @@
 
       // Save current complete data to configured Gist (internal; called after preview confirm)
       const performSaveToGist = async () => {
-        // Fallback to localStorage and trim before validation
         const id = (gistId || localStorage.getItem('gistId') || '').trim();
-        const token = (gistToken || localStorage.getItem('gistToken') || '').trim();
+        const token = (gistToken || '').trim();
         if (!id || !token) {
           console.warn('Save to Gist blocked: missing credentials', { hasId: !!id, hasToken: !!token });
           setShowSettings(true);
@@ -501,7 +577,7 @@
         }
         try {
           setIsSaving(true);
-          console.log('Saving to Gist...', { id: id.slice(0,4) + '...' + id.slice(-4), tokenLength: token.length });
+          console.log('Saving to Gist...', { id: id.slice(0,4) + '...' + id.slice(-4) });
           
           // Ensure we save the complete data structure including gameResults
           const dataToSave = getDataToSave();
@@ -525,6 +601,7 @@
           }
           setDirty(false);
           setBaselineJson(JSON.stringify(dataToSave, null, 2));
+          setGistToken('');
           showNotification('Saved to Gist successfully', 'success');
         } catch (err) {
           console.error(err);
@@ -538,13 +615,13 @@
       const saveSettings = () => {
         const id = (gistId || '').trim();
         const token = (gistToken || '').trim();
-        // Persist and update state immediately so Save to Gist can use them without reload
+        // Only the non-secret Gist ID is persisted. The token stays in memory for this tab.
         localStorage.setItem('gistId', id);
-        localStorage.setItem('gistToken', token);
+        localStorage.removeItem('gistToken');
         setGistId(id);
         setGistToken(token);
         setShowSettings(false);
-        showNotification('Settings saved locally', 'success');
+        showNotification(token ? 'Gist ID saved; token kept only for this tab' : 'Gist ID saved; enter a token before saving data', 'success');
       };
       
       const resetElimination = (managerIndex) => {
@@ -674,8 +751,7 @@
               </div>
               
               <div className="mt-6 text-center text-sm text-purple-300">
-                <p>Default password: <span className="font-mono">survivor2026</span></p>
-                <p className="mt-2">Change this after first login for security</p>
+                <p>This is a local convenience lock. GitHub write access still requires a separate session-only token.</p>
               </div>
             </div>
           </div>
@@ -752,6 +828,7 @@
                   <button
                     onClick={() => {
                       localStorage.removeItem('adminAuthenticated');
+                      setGistToken('');
                       setAuthenticated(false);
                     }}
                     className="px-4 py-2 bg-red-600 hover:bg-red-700 rounded-lg transition-colors"
@@ -766,6 +843,12 @@
                   You have unsaved changes. Click "Save to Gist".
                 </div>
               )}
+              <div className="text-sm mt-3 flex flex-wrap items-center gap-2 text-purple-200">
+                <span>Data source:</span>
+                <span className={`px-2 py-0.5 rounded-full font-bold text-xs ${dataSource === 'gist' ? 'bg-green-500/30 text-green-100' : dataSource === 'repository' ? 'bg-amber-400 text-black' : 'bg-gray-600 text-white'}`}>
+                  {dataSource === 'gist' ? 'LIVE GIST' : dataSource === 'repository' ? 'REPOSITORY FALLBACK' : dataSource.toUpperCase()}
+                </span>
+              </div>
             </header>
             
             {/* JSON Editor */}
@@ -778,7 +861,7 @@
                   <pre className="text-sm text-green-300">{jsonData}</pre>
                 </div>
                 <div className="mt-4 text-sm text-purple-300">
-                  <p>After making changes, download this file and replace the data.json in your repository.</p>
+                  <p>Use this view to inspect the exact JSON that will be saved to the live Gist.</p>
                 </div>
               </div>
             )}
@@ -911,11 +994,11 @@
                       <span className="font-bold">{manager.marginOfVictory}</span>
                     </div>
                     <div>
-                      <span className="text-sm">Last Year Rank: </span>
+                      <span className="text-sm">2025 Tiebreak Rank (1 is best): </span>
                       <input
                         type="number"
                         min="1"
-                        max="20"
+                        max={managers.length}
                         value={manager.lastYearRank}
                         onChange={(e) => handleManagerInfoChange(managerIndex, 'lastYearRank', parseInt(e.target.value))}
                         className="w-16 p-1 rounded text-white focus:outline-none focus:ring-1 focus:ring-purple-500"
@@ -951,16 +1034,16 @@
             {/* Instructions */}
             <div className="glass rounded-2xl p-5">
               <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
-                <i className="fas fa-info-circle"></i> How to Update Your Site
+                <i className="fas fa-info-circle"></i> How to Publish Pool Changes
               </h2>
               <ol className="list-decimal pl-5 space-y-2">
                 <li>Make changes to manager picks and results using the forms above</li>
-                <li>Click "Download data.json" to get the updated file</li>
-                <li>Go to your GitHub repository and replace the existing data.json file with your downloaded version</li>
-                <li>Commit and push the changes to update your live site</li>
+                <li>Review the unique 2025 tiebreak ranks (1 is best)</li>
+                <li>Click "Save to Gist" and review the validation/diff preview</li>
+                <li>Enter a short-lived Gist-only token when asked, then confirm the save</li>
               </ol>
               <div className="mt-4 p-4 bg-yellow-500/20 rounded-lg">
-                <p className="text-sm"><strong>Note:</strong> Changes will appear on the live site after a few minutes once GitHub Pages updates.</p>
+                <p className="text-sm"><strong>Note:</strong> The public site reads the Gist directly, so saved changes usually appear after a refresh. Download data.json after major changes as an extra backup.</p>
               </div>
             </div>
           </div>
@@ -998,10 +1081,12 @@
                       type="password"
                       value={gistToken}
                       onChange={(e) => setGistToken(e.target.value)}
+                      autoComplete="off"
+                      spellCheck="false"
                       className="w-full p-3 rounded-lg bg-white/10 border border-white/20 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
-                      placeholder="token stored locally"
+                      placeholder="paste token for this save"
                     />
-                    <p className="text-xs text-purple-200 mt-1">Stored only in your browser (localStorage). Required to save.</p>
+                    <p className="text-xs text-purple-200 mt-1">Kept only in this open tab, never saved to browser storage, and cleared after a successful save.</p>
                   </div>
                 </div>
                 <div className="flex justify-end gap-3 mt-6">
@@ -1144,11 +1229,11 @@
                   </div>
                   
                   <div>
-                    <label className="block text-sm font-medium mb-1">Last Year Rank</label>
+                    <label className="block text-sm font-medium mb-1">2025 Tiebreak Rank (1 is best)</label>
                     <input
                       type="number"
                       min="1"
-                      max="20"
+                      max={managers.length + 1}
                       value={newManager.lastYearRank}
                       onChange={(e) => setNewManager({...newManager, lastYearRank: parseInt(e.target.value) || 11})}
                       className="w-full p-3 rounded-lg bg-white/10 border border-white/20 text-white focus:outline-none focus:ring-2 focus:ring-purple-500"

--- a/index.html
+++ b/index.html
@@ -12,17 +12,16 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <!-- Tailwind CSS via Play CDN for rapid styling -->
+  <!-- Version-pinned CDN assets with integrity checks. -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <!-- React and ReactDOM (development builds for easier debugging) -->
-  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" integrity="sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1" crossorigin="anonymous"></script>
   <!-- Chart.js for rendering bar charts -->
-  <script crossorigin src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" integrity="sha384-e6nUZLBkQ86NJ6TVVKAeSaK8jWa3NhkYWZFomE39AvDbQWeie9PlQqM3pmYW5d1g" crossorigin="anonymous"></script>
   <!-- Babel Standalone enables JSX in the browser -->
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.28.5/babel.min.js" integrity="sha384-mP9sW+eK08VvAmlxEkn9Kn6egvKFtnFEfW7/u9feUWAIoTvnYAzT4NwsskP+uWUd" crossorigin="anonymous"></script>
   <!-- Font Awesome for icons -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">
   <!-- Simple styling overrides -->
   <style>
     body {
@@ -235,12 +234,8 @@
       const [muted, setMuted] = useState(localStorage.getItem('mutedAudio') === 'true');
       // Breakdown toggles per manager
       const [openBreakdowns, setOpenBreakdowns] = useState(new Set());
-      // Public auto-persist controls
-      const [autoPersist, setAutoPersist] = useState(localStorage.getItem('autoPersistEnabled') === 'true');
-      const [gistIdState, setGistIdState] = useState((localStorage.getItem('gistId') || '').trim());
-      const [gistSeasonReady, setGistSeasonReady] = useState(false);
-      const saveDebounceRef = useRef(null);
-      const lastSavedHashRef = useRef('');
+      // Public data is always read-only. The source badge makes the active source explicit.
+      const [dataSource, setDataSource] = useState('loading');
       // Keep a synchronous reference to gistId to avoid async state timing issues
       const gistIdRef = useRef((localStorage.getItem('gistId') || '').trim());
       // Feature flags and Fantasy ADP state
@@ -600,7 +595,7 @@
       // Function to load data with cache-busting (prefers Gist via config.json)
       const loadData = async () => {
         setRefreshing(true);
-        setGistSeasonReady(false);
+        setDataSource('loading');
         const timestamp = new Date().getTime();
         // Try to read gistId from config.json
         let gistId = '';
@@ -645,7 +640,6 @@
         }
         // Store gistId in a ref for immediate availability to fetchers
         gistIdRef.current = gistId;
-        setGistIdState(gistId);
         // If gistId configured, try Gist first
         if (gistId) {
           try {
@@ -665,7 +659,7 @@
             setManagers(data.managers || []);
             setGameResults(data.gameResults || {});
             setLastUpdated(data.lastUpdated || '');
-            setGistSeasonReady(true);
+            setDataSource('gist');
             setLoading(false);
             setRefreshing(false);
             await fetchADPIfEnabled(cfgFeatures);
@@ -688,11 +682,13 @@
           setManagers(data.managers || []);
           setGameResults(data.gameResults || {});
           setLastUpdated(data.lastUpdated || '');
+          setDataSource('repository');
           setLoading(false);
           setRefreshing(false);
           await fetchADPIfEnabled(cfgFeatures);
         } catch (error) {
           console.error('Error loading data:', error);
+          setDataSource('error');
           setLoading(false);
           setRefreshing(false);
         }
@@ -703,10 +699,11 @@
         loadData();
       }, []);
 
-      // Persist autoPersist preference locally
+      // Remove credentials/preferences left by older public auto-save builds.
       useEffect(() => {
-        localStorage.setItem('autoPersistEnabled', autoPersist ? 'true' : 'false');
-      }, [autoPersist]);
+        localStorage.removeItem('autoPersistEnabled');
+        localStorage.removeItem('gistToken');
+      }, []);
 
       // Persist mute preference locally
       useEffect(() => {
@@ -1138,60 +1135,6 @@
 
       const orderedManagers = useMemo(() => computeDraftOrderLive(managers), [managers, games, preseasonSchedule]);
 
-      // Public-side Gist save (opt-in). Uses gistId from config/localStorage and gistToken from localStorage.
-      const saveToGistPublic = async (jsonStr) => {
-        const id = (gistIdState || localStorage.getItem('gistId') || '').trim();
-        const token = (localStorage.getItem('gistToken') || '').trim();
-        if (!id || !token) {
-          console.warn('Auto-save skipped: missing Gist credentials');
-          return;
-        }
-        try {
-          const payload = { files: { 'data.json': { content: jsonStr } } };
-          const res = await fetch(`https://api.github.com/gists/${id}`, {
-            method: 'PATCH',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `token ${token}`
-            },
-            body: JSON.stringify(payload)
-          });
-          if (!res.ok) {
-            const t = await res.text();
-            throw new Error(`Gist save failed: ${res.status} ${t}`);
-          }
-          console.log('Auto-saved live results to Gist');
-        } catch (err) {
-          console.error('Auto-save to Gist failed:', err);
-        }
-      };
-
-      // Debounced auto-persist when managers change and toggle is enabled
-      useEffect(() => {
-        if (!autoPersist || !gistSeasonReady) return;
-        const id = (gistIdState || localStorage.getItem('gistId') || '').trim();
-        const token = (localStorage.getItem('gistToken') || '').trim();
-        if (!id || !token) return;
-        const payloadObj = {
-          season: SEASON_YEAR,
-          managers,
-          gameResults,
-          lastUpdated: new Date().toISOString()
-        };
-        const payloadStr = JSON.stringify(payloadObj, null, 2);
-        if (lastSavedHashRef.current === payloadStr) return;
-        if (saveDebounceRef.current) clearTimeout(saveDebounceRef.current);
-        saveDebounceRef.current = setTimeout(async () => {
-          await saveToGistPublic(payloadStr);
-          lastSavedHashRef.current = payloadStr;
-        }, 3000);
-        return () => {
-          if (saveDebounceRef.current) {
-            clearTimeout(saveDebounceRef.current);
-            saveDebounceRef.current = null;
-          }
-        };
-      }, [managers, gameResults, autoPersist, gistIdState, gistSeasonReady]);
       // Initialize mobile/desktop defaults for expansions and chart section ONCE after data loads
       useEffect(() => {
         if (initViewApplied.current) return;
@@ -1522,27 +1465,19 @@
             style={{ paddingTop: 'calc(0.5rem + env(safe-area-inset-top))' }}
           >
             <div className="flex items-center justify-between gap-3">
-              <div className="text-xs text-purple-200 whitespace-nowrap flex items-center gap-2">
+              <div className="text-xs text-purple-200 flex flex-wrap items-center gap-2">
                 <span>Last updated: {lastUpdated ? new Date(lastUpdated).toLocaleString() : '—'}</span>
+                <span
+                  className={`px-2 py-0.5 rounded-full font-bold text-[10px] ${dataSource === 'gist' ? 'bg-green-500/30 text-green-100' : dataSource === 'repository' ? 'bg-amber-400 text-black' : 'bg-gray-600 text-white'}`}
+                  title={dataSource === 'gist' ? 'Live commissioner data from GitHub Gist' : dataSource === 'repository' ? 'Fallback starter data from the repository' : 'Data source status'}
+                >
+                  {dataSource === 'gist' ? 'LIVE GIST' : dataSource === 'repository' ? 'FALLBACK DATA' : dataSource.toUpperCase()}
+                </span>
                 {isStale && (
                   <span className="px-2 py-0.5 rounded-full bg-amber-400 text-black font-bold text-[10px]" title="Live data may be out of date">STALE</span>
                 )}
               </div>
               <div className="flex items-center gap-3">
-                <label
-                  className={`hidden sm:flex items-center gap-2 text-xs select-none ${gistSeasonReady ? '' : 'opacity-60'}`}
-                  title={gistSeasonReady ? 'Automatically save live results to your configured Gist' : `Initialize the ${SEASON_YEAR} Gist from the admin page first`}
-                >
-                  <input
-                    type="checkbox"
-                    checked={autoPersist}
-                    onChange={(e) => setAutoPersist(e.target.checked)}
-                    disabled={!gistSeasonReady}
-                    aria-label="Enable auto-save to Gist"
-                    className="h-4 w-4 rounded border-purple-400 bg-transparent"
-                  />
-                  Auto-save to Gist
-                </label>
                 {/* Global mute toggle (mobile only) */}
                 <button
                   onClick={() => setMuted(m => !m)}
@@ -1589,6 +1524,13 @@
                 <i className={`fas fa-sync-alt mr-1 ${refreshing ? 'animate-rotate' : ''}`}></i>
                 {cooldownMs > 0 ? `Wait ${Math.ceil(cooldownMs/1000)}s` : 'Refresh'}
               </button>
+            </div>
+          )}
+
+          {dataSource === 'repository' && (
+            <div className="mt-2 glass rounded-lg px-3 py-2 -mx-1 md:mx-0 border border-amber-400/40 text-amber-100 flex items-center gap-2" role="status">
+              <i className="fas fa-database text-amber-300" aria-hidden="true"></i>
+              <span>Showing repository fallback data because the live Gist is unavailable or for another season.</span>
             </div>
           )}
 
@@ -1652,7 +1594,7 @@
             </div>
             <div className="glass rounded-xl p-4 text-center">
               <div className="text-3xl font-bold text-purple-400">{orderedManagers[0]?.name || '-'}</div>
-              <div className="text-sm">Current Leader</div>
+              <div className="text-sm">{calendar.completedWeeks === 0 ? 'Projected #1 (Tiebreaker)' : 'Current Leader'}</div>
             </div>
           </div>
 
@@ -2430,7 +2372,7 @@
           {/* Footer */}
           <footer className="text-center py-6 text-sm text-purple-300 border-t border-white/10">
             <p>{SEASON_YEAR} NFL Preseason Survivor Pool • Draft order determined by survival and margin of victory</p>
-            <p className="mt-1">Admin: <a href="admin.html" className="text-purple-200 hover:text-white">Manage Pool</a></p>
+            <p className="mt-1">Public results are read-only and refresh from the commissioner’s live data.</p>
           </footer>
         </div>
       );

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Minimal service worker for installability and basic offline support */
-const CACHE_NAME = 'survivor-pool-v2-20260812';
+const CACHE_NAME = 'survivor-pool-v3-20260812';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## What changed
- made the public pool strictly read-only and removed its Gist write/token path
- added clear live-Gist versus repository-fallback status
- clarified the preseason tiebreaker leader before any games are complete
- kept admin Gist tokens in memory only and cleared legacy stored tokens
- added rank, manager-name, repeat-pick, schema, and import validation
- added unsaved-change protection, admin no-index metadata, and clearer publishing instructions
- pinned third-party runtime assets with integrity checks where supported
- bumped the service-worker cache for a clean rollout

## Why
The group-facing page previously exposed an admin link and could write to the data Gist from a browser-stored token. The admin also allowed conflicting tiebreak ranks and could continue when schema validation was unavailable.

## Impact
League members get a safer read-only results page. Commissioner updates still publish through the admin, but the GitHub token is session-only and invalid pool data is blocked before saving.

## Validation
- verified 2026 Gist roster, Michael / The Sacks Kingdom, and ranks 1–10
- exercised duplicate-rank validation and confirmed final save is disabled
- tested public and admin pages in the browser
- checked 390×844 mobile layout for horizontal overflow
- ran `git diff --check`