### PR TITLE
Add public weekly pick queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Single-page React app (vanilla React via `<script>` in `index.html`) hosted on GitHub Pages. It tracks preseason picks, live scores, cumulative margins, eliminations, and fantasy draft order. The companion `admin.html` page manages picks and can persist them to a GitHub Gist.
+Single-page React app (vanilla React via `<script>` in `index.html`) hosted on GitHub Pages. It tracks preseason picks, live scores, cumulative margins, eliminations, and fantasy draft order. The public page includes an honor-system weekly pick queue, while the companion `admin.html` page manages overrides and persists data to a GitHub Gist.
 
 ## 2026 Season
 
@@ -22,13 +22,15 @@ Single-page React app (vanilla React via `<script>` in `index.html`) hosted on G
 - Picks lock at their explicit Eastern Time kickoff.
 - Audio assets lazy-load and a global mute preference persists in `localStorage`.
 - The admin validates data and previews changes before saving to the Gist.
+- The public queue shows only the next eligible manager, validates the active week and deadline, and advances after one accepted pick.
 
 ## Data and Persistence
 
 - Public reads use the configured GitHub Gist only when it matches the active season; otherwise they fall back to `data.json`.
-- The public site is strictly read-only. It never stores a GitHub token and cannot write to the Gist.
+- The public site never receives or stores a GitHub token. Pick submissions go to a Cloudflare Durable Object that serializes turns and writes to the Gist with a server-side secret.
 - Admin writes require a short-lived Gist-only token. The token is kept only in the open admin tab, is never written to `localStorage`, and is cleared after a successful save.
 - The admin validates unique manager names, unique tiebreak ranks from 1 through the manager count, and duplicate team picks before saving.
+- `data.json.pickQueue` controls the enabled state, active week, explicit turn order, and weekly deadlines. The admin can open/close the queue and advance its active week.
 - Fantasy ADP is configured for 2026 in `config.json`.
 
 ## Local Development
@@ -45,6 +47,12 @@ Browser state:
 - The default admin password for a new browser is `survivor2026`; change it after first login.
 
 The admin password is a local convenience lock, not server-side authentication. The GitHub token is the write credential and should be narrowly scoped, short-lived, and revoked after the pool ends.
+
+## Pick Queue Worker
+
+The Worker lives in `worker/` and uses one SQLite-backed Durable Object to serialize submissions. Deploy it from that directory with Wrangler, then set the `GIST_TOKEN` secret to a token with Gists write permission. `GIST_ID`, allowed browser origins, and the season are non-secret Wrangler variables.
+
+There is intentionally no manager login. Anyone with the pool URL can act for the manager whose turn is displayed, so the queue enforces order and data rules but relies on the league's honor system for identity.
 
 ## Notes
 

--- a/admin.html
+++ b/admin.html
@@ -177,10 +177,21 @@
       // Lightweight JSON Schema for admin validation (kept permissive to avoid blocking legitimate data)
       const jsonSchema = {
         type: 'object',
-        required: ['season', 'managers'],
+        required: ['season', 'managers', 'pickQueue'],
         additionalProperties: true,
         properties: {
           season: { type: 'integer', const: SEASON_YEAR },
+          pickQueue: {
+            type: 'object',
+            required: ['enabled', 'activeWeek', 'order', 'deadlines'],
+            additionalProperties: true,
+            properties: {
+              enabled: { type: 'boolean' },
+              activeWeek: { type: 'integer', minimum: 1, maximum: 3 },
+              order: { type: 'array', minItems: 1, uniqueItems: true, items: { type: 'string', minLength: 1 } },
+              deadlines: { type: 'object', additionalProperties: { type: 'string' } }
+            }
+          },
           managers: {
             type: 'array',
             items: {
@@ -255,6 +266,28 @@
             usedTeams.add(team);
           });
         });
+
+        const queue = data && data.pickQueue;
+        if (queue && Array.isArray(queue.order)) {
+          const managerNames = new Set(poolManagers.map((manager) => String(manager && manager.name || '').trim().toLowerCase()));
+          const queueNames = new Set();
+          queue.order.forEach((name, index) => {
+            const key = String(name || '').trim().toLowerCase();
+            if (!managerNames.has(key)) {
+              errors.push({ instancePath: `/pickQueue/order/${index}`, message: `references unknown manager ${name}` });
+            }
+            if (queueNames.has(key)) {
+              errors.push({ instancePath: `/pickQueue/order/${index}`, message: `duplicates manager ${name}` });
+            }
+            queueNames.add(key);
+          });
+          poolManagers.forEach((manager) => {
+            const name = String(manager && manager.name || '').trim();
+            if (name && !queueNames.has(name.toLowerCase())) {
+              errors.push({ instancePath: '/pickQueue/order', message: `is missing manager ${name}` });
+            }
+          });
+        }
 
         return errors;
       };
@@ -512,6 +545,30 @@
         setDirty(true);
       };
 
+      const updatePickQueue = (changes) => {
+        const fallbackOrder = managers
+          .slice()
+          .sort((a, b) => Number(a.lastYearRank || 999) - Number(b.lastYearRank || 999))
+          .map((manager) => manager.name);
+        const data = {
+          ...completeData,
+          season: SEASON_YEAR,
+          managers,
+          pickQueue: {
+            enabled: false,
+            activeWeek: 1,
+            order: fallbackOrder,
+            deadlines: {},
+            ...(completeData.pickQueue || {}),
+            ...changes
+          },
+          lastUpdated: new Date().toISOString()
+        };
+        setCompleteData(data);
+        setJsonData(JSON.stringify(data, null, 2));
+        setDirty(true);
+      };
+
       // Copy current JSON to clipboard
       const copyJson = async () => {
         try {
@@ -757,6 +814,19 @@
           </div>
         );
       }
+
+      const fallbackQueueOrder = managers
+        .slice()
+        .sort((a, b) => Number(a.lastYearRank || 999) - Number(b.lastYearRank || 999))
+        .map((manager) => manager.name);
+      const pickQueueConfig = {
+        enabled: false,
+        activeWeek: 1,
+        order: fallbackQueueOrder,
+        deadlines: {},
+        ...(completeData.pickQueue || {})
+      };
+      const activeQueueDeadline = pickQueueConfig.deadlines && pickQueueConfig.deadlines[String(pickQueueConfig.activeWeek)];
       
       return (
         <div className="min-h-screen p-4">
@@ -876,6 +946,64 @@
                 Add New Manager
               </button>
             </div>
+
+            {/* Public Pick Queue Controls */}
+            <section className="glass rounded-2xl p-5 mb-8">
+              <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                <div>
+                  <h2 className="text-xl font-semibold flex items-center gap-2">
+                    <i className="fas fa-people-arrows"></i> Public Pick Queue
+                  </h2>
+                  <p className="text-sm text-purple-200 mt-1">Open one week at a time. The public page advances through this order after each accepted pick.</p>
+                </div>
+                <label className="flex items-center gap-2 rounded-lg bg-black/20 px-3 py-2">
+                  <input
+                    type="checkbox"
+                    checked={pickQueueConfig.enabled === true}
+                    onChange={(event) => updatePickQueue({ enabled: event.target.checked })}
+                    className="h-4 w-4"
+                  />
+                  <span className="font-semibold">{pickQueueConfig.enabled ? 'Queue open' : 'Queue closed'}</span>
+                </label>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-5">
+                <div>
+                  <label className="block text-sm mb-1">Active Week</label>
+                  <select
+                    value={pickQueueConfig.activeWeek}
+                    onChange={(event) => updatePickQueue({ activeWeek: Number(event.target.value) })}
+                    className="w-full p-2 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  >
+                    {[1, 2, 3].map((week) => <option key={week} value={week}>Week {week}</option>)}
+                  </select>
+                </div>
+                <div className="md:col-span-2">
+                  <label className="block text-sm mb-1">Deadline</label>
+                  <div className="p-2 rounded-lg bg-black/20 text-purple-100 min-h-[42px]">
+                    {activeQueueDeadline ? new Date(activeQueueDeadline).toLocaleString([], { timeZone: 'America/New_York', dateStyle: 'medium', timeStyle: 'short' }) + ' ET' : 'No deadline configured'}
+                  </div>
+                </div>
+              </div>
+              <div className="mt-5">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-2">
+                  <span className="text-sm font-semibold">Turn order</span>
+                  <button
+                    onClick={() => updatePickQueue({ order: fallbackQueueOrder })}
+                    className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-sm"
+                  >
+                    Use 2025 tiebreak order
+                  </button>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {pickQueueConfig.order.map((name, index) => (
+                    <span key={`${name}-${index}`} className="px-3 py-1 rounded-full bg-purple-600/40 border border-purple-300/20 text-sm">
+                      {index + 1}. {name}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <p className="text-xs text-purple-300 mt-4">Save to Gist after changing these controls. Closing the queue takes effect as soon as the Gist save completes.</p>
+            </section>
             
             {/* Manager Cards */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">

--- a/config.json
+++ b/config.json
@@ -3,6 +3,11 @@
     "gistId": "870a75b6f5a4a7797bc90e6eefdd90a3",
     "features": {
       "showFantasyADP": true,
+      "pickSubmission": {
+        "enabled": true,
+        "apiBase": "https://howboutit-picks.enjoinick.workers.dev",
+        "pollSeconds": 12
+      },
       "adp": {
         "scoring": "ppr",
         "teams": 10,

--- a/config.sample.json
+++ b/config.sample.json
@@ -3,6 +3,11 @@
   "gistId": "YOUR_GIST_ID_HERE",
   "features": {
     "showFantasyADP": true,
+    "pickSubmission": {
+      "enabled": false,
+      "apiBase": "https://YOUR_PICK_WORKER.workers.dev",
+      "pollSeconds": 12
+    },
     "adp": {
       "scoring": "ppr",
       "teams": 10,

--- a/data.json
+++ b/data.json
@@ -1,5 +1,27 @@
 {
   "season": 2026,
+  "pickQueue": {
+    "enabled": true,
+    "activeWeek": 1,
+    "order": [
+      "Weston",
+      "Jordan",
+      "Josh",
+      "Chris",
+      "Austin",
+      "Matt",
+      "Kevin",
+      "Michael",
+      "Ryan",
+      "Nick"
+    ],
+    "deadlines": {
+      "1": "2026-08-13T19:00:00-04:00",
+      "2": "2026-08-20T20:00:00-04:00",
+      "3": "2026-08-27T19:00:00-04:00"
+    },
+    "lastSubmission": null
+  },
   "managers": [
     {
       "name": "Kevin",

--- a/index.html
+++ b/index.html
@@ -241,12 +241,22 @@
       // Feature flags and Fantasy ADP state
       const [features, setFeatures] = useState({
         showFantasyADP: false,
+        pickSubmission: { enabled: false, apiBase: '', pollSeconds: 12 },
         adp: { scoring: 'ppr', teams: 10, year: SEASON_YEAR, topN: 100 }
       });
       const [fantasyADP, setFantasyADP] = useState([]);
       const [adpLoading, setAdpLoading] = useState(false);
       const [adpError, setAdpError] = useState('');
       const [adpPosition, setAdpPosition] = useState('ALL');
+      // Public, no-login pick queue. The Worker remains authoritative for turn order.
+      const [pickConfig, setPickConfig] = useState({ enabled: false, apiBase: '', pollSeconds: 12 });
+      const [pickQueue, setPickQueue] = useState(null);
+      const [pickQueueLoading, setPickQueueLoading] = useState(false);
+      const [pickTeam, setPickTeam] = useState('');
+      const [pickSubmitting, setPickSubmitting] = useState(false);
+      const [pickError, setPickError] = useState('');
+      const [pickSuccess, setPickSuccess] = useState('');
+      const [showPickConfirm, setShowPickConfirm] = useState(false);
 
       // Manual refresh throttling
       const REFRESH_THROTTLE_MS = 15000; // 15s between manual refreshes
@@ -611,8 +621,12 @@
               setFeatures(prev => ({
                 ...prev,
                 ...cfg.features,
+                pickSubmission: { ...prev.pickSubmission, ...(cfg.features.pickSubmission || {}) },
                 adp: { ...prev.adp, ...(cfg.features.adp || {}) }
               }));
+              if (cfg.features.pickSubmission) {
+                setPickConfig(prev => ({ ...prev, ...cfg.features.pickSubmission }));
+              }
             }
           }
         } catch (e) {
@@ -698,6 +712,87 @@
       useEffect(() => {
         loadData();
       }, []);
+
+      const mergeQueuePicks = (queue) => {
+        if (!queue || !Array.isArray(queue.entries)) return;
+        setManagers(current => current.map(manager => {
+          const entry = queue.entries.find(candidate => candidate.name === manager.name);
+          if (!entry || !entry.team) return manager;
+          const picks = (manager.picks || []).map(pick => Number(pick.week) === Number(queue.activeWeek)
+            ? { ...pick, team: entry.team }
+            : pick);
+          return { ...manager, picks };
+        }));
+        if (queue.lastUpdated) setLastUpdated(queue.lastUpdated);
+      };
+
+      const fetchPickQueue = async () => {
+        const base = String(pickConfig.apiBase || '').replace(/\/$/, '');
+        if (!pickConfig.enabled || !base) return;
+        setPickQueueLoading(true);
+        try {
+          const response = await fetch(`${base}/pick-queue?t=${Date.now()}`, { cache: 'no-store' });
+          const payload = await response.json().catch(() => ({}));
+          if (!response.ok || !payload.queue) {
+            throw new Error(payload.message || 'Pick queue is temporarily unavailable.');
+          }
+          setPickQueue(payload.queue);
+          mergeQueuePicks(payload.queue);
+          setPickError('');
+        } catch (error) {
+          setPickError(error.message || 'Pick queue is temporarily unavailable.');
+        } finally {
+          setPickQueueLoading(false);
+        }
+      };
+
+      useEffect(() => {
+        if (!pickConfig.enabled || !pickConfig.apiBase) return undefined;
+        fetchPickQueue();
+        const seconds = Math.max(8, Number(pickConfig.pollSeconds || 12));
+        const timer = setInterval(fetchPickQueue, seconds * 1000);
+        return () => clearInterval(timer);
+      }, [pickConfig.enabled, pickConfig.apiBase, pickConfig.pollSeconds]);
+
+      useEffect(() => {
+        setPickTeam('');
+        setShowPickConfirm(false);
+      }, [pickQueue && pickQueue.currentManager && pickQueue.currentManager.name, pickQueue && pickQueue.activeWeek]);
+
+      const submitPublicPick = async () => {
+        const current = pickQueue && pickQueue.currentManager;
+        const base = String(pickConfig.apiBase || '').replace(/\/$/, '');
+        if (!current || !pickTeam || !base) return;
+        setPickSubmitting(true);
+        setPickError('');
+        setPickSuccess('');
+        try {
+          const response = await fetch(`${base}/pick-queue`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              manager: current.name,
+              week: pickQueue.activeWeek,
+              team: pickTeam
+            })
+          });
+          const payload = await response.json().catch(() => ({}));
+          if (!response.ok || !payload.accepted) {
+            throw new Error(payload.message || 'The pick was not accepted. Refresh and try again.');
+          }
+          setPickQueue(payload.queue);
+          mergeQueuePicks(payload.queue);
+          setPickSuccess(`${payload.receipt.manager}'s Week ${payload.receipt.week} pick is locked in: ${payload.receipt.team}.`);
+          setPickTeam('');
+          setShowPickConfirm(false);
+          await loadData();
+        } catch (error) {
+          setPickError(error.message || 'The pick was not accepted.');
+          await fetchPickQueue();
+        } finally {
+          setPickSubmitting(false);
+        }
+      };
 
       // Remove credentials/preferences left by older public auto-save builds.
       useEffect(() => {
@@ -1577,6 +1672,155 @@
               </div>
             </div>
           </div>
+
+          {/* Honor-system weekly pick queue */}
+          {pickConfig.enabled && (
+            <section className="glass rounded-2xl p-5 md:p-6 border border-cyan-300/30 animate-fade-in" aria-labelledby="pick-queue-heading">
+              <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-5">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="px-2 py-1 rounded-full bg-cyan-400 text-indigo-950 text-xs font-black">YOUR TURN</span>
+                    <span className="text-sm text-purple-200">No login required • honor system</span>
+                  </div>
+                  <h2 id="pick-queue-heading" className="text-2xl md:text-3xl font-bold mt-3">
+                    Week {pickQueue ? pickQueue.activeWeek : '—'} Pick Queue
+                  </h2>
+                  {pickQueue && pickQueue.deadline && (
+                    <p className="text-sm text-purple-200 mt-1">
+                      Deadline: {new Date(pickQueue.deadline).toLocaleString([], { timeZone: 'America/New_York', dateStyle: 'medium', timeStyle: 'short' })} ET
+                    </p>
+                  )}
+                </div>
+                <button
+                  onClick={fetchPickQueue}
+                  disabled={pickQueueLoading || pickSubmitting}
+                  className="self-start px-3 py-2 rounded-lg bg-white/10 hover:bg-white/20 disabled:opacity-50 text-sm"
+                >
+                  <i className={`fas fa-rotate mr-2 ${pickQueueLoading ? 'animate-rotate' : ''}`}></i>
+                  Refresh queue
+                </button>
+              </div>
+
+              {pickQueueLoading && !pickQueue && (
+                <div className="mt-5 rounded-xl bg-black/20 p-5 text-center text-purple-200">Checking whose turn it is…</div>
+              )}
+
+              {pickError && (
+                <div className="mt-5 rounded-xl border border-red-400/40 bg-red-500/20 p-4 text-red-100" role="alert">
+                  <i className="fas fa-circle-exclamation mr-2"></i>{pickError}
+                </div>
+              )}
+
+              {pickSuccess && (
+                <div className="mt-5 rounded-xl border border-green-300/40 bg-green-500/20 p-4 text-green-100" role="status">
+                  <i className="fas fa-circle-check mr-2"></i>{pickSuccess}
+                </div>
+              )}
+
+              {pickQueue && !pickQueue.enabled && (
+                <div className="mt-5 rounded-xl bg-black/20 p-5 text-center">
+                  <div className="text-xl font-bold">The commissioner has closed this week’s queue.</div>
+                  <p className="text-purple-200 mt-1">Check back when picks open.</p>
+                </div>
+              )}
+
+              {pickQueue && pickQueue.enabled && pickQueue.locked && (
+                <div className="mt-5 rounded-xl border border-amber-300/40 bg-amber-500/20 p-5 text-center">
+                  <div className="text-xl font-bold">Week {pickQueue.activeWeek} picks are locked.</div>
+                  <p className="text-amber-100 mt-1">The submission deadline has passed. Contact the commissioner for a correction.</p>
+                </div>
+              )}
+
+              {pickQueue && pickQueue.enabled && !pickQueue.locked && pickQueue.complete && (
+                <div className="mt-5 rounded-xl border border-green-300/40 bg-green-500/20 p-5 text-center">
+                  <div className="text-xl font-bold">Everybody eligible has picked for Week {pickQueue.activeWeek}.</div>
+                  <p className="text-green-100 mt-1">Good work, degenerates. The commissioner will open the next week.</p>
+                </div>
+              )}
+
+              {pickQueue && pickQueue.enabled && !pickQueue.locked && !pickQueue.complete && pickQueue.currentManager && (
+                <div className="mt-5 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(280px,0.75fr)] gap-5">
+                  <div className="rounded-xl bg-gradient-to-br from-cyan-500/25 to-purple-600/25 border border-cyan-200/30 p-5">
+                    <p className="text-sm uppercase tracking-wider text-cyan-100 font-bold">Pick {pickQueue.currentManager.position} of {pickQueue.currentManager.total}</p>
+                    <div className="text-3xl font-black mt-1">{pickQueue.currentManager.name}, you’re up.</div>
+                    <div className="text-purple-100 mt-1">{pickQueue.currentManager.teamLabel}</div>
+                    <p className="text-sm text-purple-200 mt-4">Only this manager’s pick will be accepted. Once submitted, the queue advances to the next name.</p>
+                  </div>
+                  <div className="rounded-xl bg-black/20 p-5">
+                    <label htmlFor="public-pick-team" className="block font-semibold mb-2">Choose an NFL team</label>
+                    <select
+                      id="public-pick-team"
+                      value={pickTeam}
+                      onChange={(event) => {
+                        setPickTeam(event.target.value);
+                        setPickError('');
+                        setPickSuccess('');
+                      }}
+                      className="w-full p-3 rounded-lg bg-indigo-950 border border-white/20 text-white focus:outline-none focus:ring-2 focus:ring-cyan-300"
+                    >
+                      <option value="">Select a team…</option>
+                      {pickQueue.availableTeams.map(team => <option key={team} value={team}>{team}</option>)}
+                    </select>
+                    <button
+                      onClick={() => setShowPickConfirm(true)}
+                      disabled={!pickTeam || pickSubmitting}
+                      className="w-full mt-3 px-4 py-3 rounded-lg bg-cyan-400 hover:bg-cyan-300 text-indigo-950 font-black disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      Review {pickQueue.currentManager.name}’s pick
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {pickQueue && Array.isArray(pickQueue.entries) && (
+                <div className="mt-5">
+                  <div className="text-sm font-semibold text-purple-100 mb-2">Queue progress</div>
+                  <div className="flex flex-wrap gap-2">
+                    {pickQueue.entries.map(entry => (
+                      <span
+                        key={entry.name}
+                        className={`px-3 py-1.5 rounded-full text-sm border ${entry.status === 'picked' ? 'bg-green-500/25 border-green-300/40 text-green-100' : entry.status === 'current' ? 'bg-cyan-400 text-indigo-950 border-cyan-200 font-black' : entry.status === 'ineligible' ? 'bg-gray-700/60 border-gray-500 text-gray-300 line-through' : 'bg-black/20 border-white/10 text-purple-200'}`}
+                        title={entry.team || entry.status}
+                      >
+                        {entry.position}. {entry.name}{entry.status === 'picked' ? ' ✓' : ''}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </section>
+          )}
+
+          {showPickConfirm && pickQueue && pickQueue.currentManager && (
+            <div className="fixed inset-0 z-[100] bg-black/75 flex items-center justify-center p-4" role="dialog" aria-modal="true" aria-labelledby="confirm-pick-heading">
+              <div className="glass rounded-2xl p-6 max-w-md w-full border border-cyan-300/40">
+                <h2 id="confirm-pick-heading" className="text-2xl font-bold">Lock in this pick?</h2>
+                <div className="mt-4 rounded-xl bg-black/25 p-4">
+                  <div className="text-sm text-purple-200">Manager</div>
+                  <div className="text-xl font-bold">{pickQueue.currentManager.name}</div>
+                  <div className="text-sm text-purple-200 mt-3">Week {pickQueue.activeWeek} team</div>
+                  <div className="text-xl font-bold text-cyan-200">{pickTeam}</div>
+                </div>
+                <p className="text-sm text-purple-200 mt-4">There is no self-service undo. If this is wrong, the commissioner can correct it in the admin page.</p>
+                <div className="flex justify-end gap-3 mt-6">
+                  <button
+                    onClick={() => setShowPickConfirm(false)}
+                    disabled={pickSubmitting}
+                    className="px-4 py-2 rounded-lg bg-gray-600 hover:bg-gray-500"
+                  >
+                    Go back
+                  </button>
+                  <button
+                    onClick={submitPublicPick}
+                    disabled={pickSubmitting}
+                    className="px-4 py-2 rounded-lg bg-cyan-400 hover:bg-cyan-300 text-indigo-950 font-black disabled:opacity-50"
+                  >
+                    {pickSubmitting ? 'Submitting…' : 'Confirm pick'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
 
           {/* Stats Overview */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 animate-fade-in">

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Minimal service worker for installability and basic offline support */
-const CACHE_NAME = 'survivor-pool-v3-20260812';
+const CACHE_NAME = 'survivor-pool-v4-20260812';
 const ASSETS = [
   './',
   './index.html',

--- a/worker/.gitignore
+++ b/worker/.gitignore
@@ -1,0 +1,3 @@
+.wrangler/
+.wrangler-dry-run/
+node_modules/

--- a/worker/dev/ui-mock-server.mjs
+++ b/worker/dev/ui-mock-server.mjs
@@ -1,0 +1,36 @@
+// Local-only API used to exercise the public pick form without touching the live Gist.
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { applySubmission, deriveQueueState, QueueError } from '../src/logic.js';
+
+let data = JSON.parse(await readFile(new URL('../../data.json', import.meta.url), 'utf8'));
+const cors = {
+  'Access-Control-Allow-Origin': 'http://127.0.0.1:8765',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Content-Type': 'application/json; charset=utf-8'
+};
+
+const send = (response, status, body) => {
+  response.writeHead(status, cors);
+  response.end(body ? JSON.stringify(body) : '');
+};
+
+createServer(async (request, response) => {
+  if (request.method === 'OPTIONS') return send(response, 204);
+  if (request.url?.split('?')[0] !== '/pick-queue') return send(response, 404, { error: 'not_found' });
+  try {
+    if (request.method === 'GET') return send(response, 200, { queue: deriveQueueState(data) });
+    if (request.method !== 'POST') return send(response, 405, { error: 'method_not_allowed' });
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const result = applySubmission(data, JSON.parse(Buffer.concat(chunks).toString('utf8')));
+    data = result.data;
+    return send(response, 201, { accepted: true, receipt: result.receipt, queue: result.queue });
+  } catch (error) {
+    const status = error instanceof QueueError ? error.status : 500;
+    return send(response, status, { error: error.code || 'internal_error', message: error.message });
+  }
+}).listen(8787, '127.0.0.1', () => {
+  console.log('Pick queue UI mock listening on http://127.0.0.1:8787');
+});

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "howboutit-pick-queue",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/logic.test.mjs test/coordinator.test.mjs",
+    "check": "node --check src/index.js && node --check src/logic.js",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "4.122.0"
+  }
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,182 @@
+import { applySubmission, deriveQueueState, QueueError } from './logic.js';
+
+const DEFAULT_ALLOWED_ORIGINS = [
+  'https://enjoinick.github.io',
+  'http://127.0.0.1:8765',
+  'http://localhost:8765'
+];
+
+const json = (body, status = 200, headers = {}) => new Response(JSON.stringify(body), {
+  status,
+  headers: {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    ...headers
+  }
+});
+
+const allowedOrigins = (env) => String(env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean)
+  .concat(DEFAULT_ALLOWED_ORIGINS);
+
+const corsHeaders = (request, env) => {
+  const origin = request.headers.get('Origin');
+  const allowed = allowedOrigins(env);
+  return origin && allowed.includes(origin)
+    ? { 'Access-Control-Allow-Origin': origin, Vary: 'Origin' }
+    : {};
+};
+
+const assertAllowedOrigin = (request, env) => {
+  const origin = request.headers.get('Origin');
+  if (!origin || !allowedOrigins(env).includes(origin)) {
+    throw new QueueError(403, 'origin_not_allowed', 'This pick must be submitted from the pool website.');
+  }
+};
+
+const githubHeaders = (env) => ({
+  Accept: 'application/vnd.github+json',
+  Authorization: `Bearer ${env.GIST_TOKEN}`,
+  'User-Agent': 'howboutit-pick-queue',
+  'X-GitHub-Api-Version': '2026-03-10'
+});
+
+const readPoolData = async (env) => {
+  if (!env.GIST_ID || !env.GIST_TOKEN) {
+    throw new QueueError(503, 'worker_not_configured', 'The pick service is not configured yet.');
+  }
+  const response = await fetch(`https://api.github.com/gists/${env.GIST_ID}`, {
+    headers: githubHeaders(env),
+    cache: 'no-store'
+  });
+  if (!response.ok) {
+    throw new QueueError(502, 'gist_read_failed', 'The live pool could not be read.');
+  }
+  const gist = await response.json();
+  const file = gist && gist.files && gist.files['data.json'];
+  if (!file || typeof file.content !== 'string' || file.truncated) {
+    throw new QueueError(502, 'gist_data_missing', 'The live data.json file is unavailable.');
+  }
+  try {
+    return JSON.parse(file.content);
+  } catch {
+    throw new QueueError(502, 'gist_data_invalid', 'The live data.json file is invalid.');
+  }
+};
+
+const writePoolData = async (env, data) => {
+  const response = await fetch(`https://api.github.com/gists/${env.GIST_ID}`, {
+    method: 'PATCH',
+    headers: {
+      ...githubHeaders(env),
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      files: {
+        'data.json': { content: JSON.stringify(data, null, 2) }
+      }
+    })
+  });
+  if (!response.ok) {
+    throw new QueueError(502, 'gist_write_failed', 'The pick could not be saved. Please try again.');
+  }
+};
+
+export class PickQueueCoordinator {
+  constructor(ctx, env) {
+    this.ctx = ctx;
+    this.env = env;
+    this.pending = Promise.resolve();
+  }
+
+  fetch(request) {
+    const run = this.pending
+      .then(() => this.handle(request))
+      .catch((error) => {
+        const status = error instanceof QueueError ? error.status : 500;
+        const code = error instanceof QueueError ? error.code : 'internal_error';
+        const message = error instanceof QueueError ? error.message : 'The pick service encountered an error.';
+        console.error('Serialized pick request failed', { code, message: error && error.message });
+        return json({ error: code, message }, status);
+      });
+    this.pending = run.then(() => undefined);
+    return run;
+  }
+
+  async handle(request) {
+    const url = new URL(request.url);
+    if (url.pathname !== '/pick-queue') {
+      return json({ error: 'not_found', message: 'Route not found.' }, 404);
+    }
+
+    if (request.method === 'GET') {
+      const data = await readPoolData(this.env);
+      return json({ queue: deriveQueueState(data) });
+    }
+
+    if (request.method === 'POST') {
+      assertAllowedOrigin(request, this.env);
+      const contentType = request.headers.get('Content-Type') || '';
+      if (!contentType.toLowerCase().includes('application/json')) {
+        throw new QueueError(415, 'json_required', 'Send the pick as JSON.');
+      }
+      let submission;
+      try {
+        submission = await request.json();
+      } catch {
+        throw new QueueError(400, 'invalid_json', 'The pick request is invalid.');
+      }
+
+      const data = await readPoolData(this.env);
+      const result = applySubmission(data, submission);
+      await writePoolData(this.env, result.data);
+      return json({ accepted: true, receipt: result.receipt, queue: result.queue }, 201);
+    }
+
+    return json({ error: 'method_not_allowed', message: 'Method not allowed.' }, 405, { Allow: 'GET, POST, OPTIONS' });
+  }
+}
+
+export default {
+  async fetch(request, env) {
+    const cors = corsHeaders(request, env);
+    if (request.method === 'OPTIONS') {
+      const origin = request.headers.get('Origin');
+      if (!origin || !allowedOrigins(env).includes(origin)) {
+        return json({ error: 'origin_not_allowed' }, 403);
+      }
+      return new Response(null, {
+        status: 204,
+        headers: {
+          ...cors,
+          'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type',
+          'Access-Control-Max-Age': '86400'
+        }
+      });
+    }
+
+    try {
+      const url = new URL(request.url);
+      if (url.pathname === '/health') {
+        return json({ status: 'ok', service: 'howboutit-pick-queue' }, 200, cors);
+      }
+      if (url.pathname !== '/pick-queue') {
+        return json({ error: 'not_found', message: 'Route not found.' }, 404, cors);
+      }
+      const id = env.PICK_QUEUE.idFromName(`season-${env.SEASON || '2026'}`);
+      const response = await env.PICK_QUEUE.get(id).fetch(request);
+      const headers = new Headers(response.headers);
+      Object.entries(cors).forEach(([key, value]) => headers.set(key, value));
+      return new Response(response.body, { status: response.status, headers });
+    } catch (error) {
+      const status = error instanceof QueueError ? error.status : 500;
+      const code = error instanceof QueueError ? error.code : 'internal_error';
+      const message = error instanceof QueueError ? error.message : 'The pick service encountered an error.';
+      console.error('Pick queue request failed', { code, message: error && error.message });
+      return json({ error: code, message }, status, cors);
+    }
+  }
+};

--- a/worker/src/logic.js
+++ b/worker/src/logic.js
@@ -1,0 +1,202 @@
+export const NFL_TEAMS = Object.freeze([
+  'Arizona Cardinals', 'Atlanta Falcons', 'Baltimore Ravens', 'Buffalo Bills',
+  'Carolina Panthers', 'Chicago Bears', 'Cincinnati Bengals', 'Cleveland Browns',
+  'Dallas Cowboys', 'Denver Broncos', 'Detroit Lions', 'Green Bay Packers',
+  'Houston Texans', 'Indianapolis Colts', 'Jacksonville Jaguars', 'Kansas City Chiefs',
+  'Las Vegas Raiders', 'Los Angeles Chargers', 'Los Angeles Rams', 'Miami Dolphins',
+  'Minnesota Vikings', 'New England Patriots', 'New Orleans Saints', 'New York Giants',
+  'New York Jets', 'Philadelphia Eagles', 'Pittsburgh Steelers', 'San Francisco 49ers',
+  'Seattle Seahawks', 'Tampa Bay Buccaneers', 'Tennessee Titans', 'Washington Commanders'
+]);
+
+const TEAM_BY_KEY = new Map(NFL_TEAMS.map((team) => [team.toLowerCase(), team]));
+
+export class QueueError extends Error {
+  constructor(status, code, message) {
+    super(message);
+    this.name = 'QueueError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+const managerKey = (value) => String(value || '').trim().toLowerCase();
+
+const findWeekPick = (manager, week) =>
+  (Array.isArray(manager && manager.picks) ? manager.picks : [])
+    .find((pick) => Number(pick && pick.week) === Number(week));
+
+const normalizeOrder = (data) => {
+  const managers = Array.isArray(data && data.managers) ? data.managers : [];
+  const managersByKey = new Map(managers.map((manager) => [managerKey(manager.name), manager]));
+  const configured = Array.isArray(data && data.pickQueue && data.pickQueue.order)
+    ? data.pickQueue.order
+    : [];
+  const ordered = [];
+  const seen = new Set();
+
+  for (const name of configured) {
+    const key = managerKey(name);
+    if (!key || seen.has(key) || !managersByKey.has(key)) continue;
+    ordered.push(managersByKey.get(key));
+    seen.add(key);
+  }
+
+  managers
+    .slice()
+    .sort((a, b) => Number(a.lastYearRank || 999) - Number(b.lastYearRank || 999))
+    .forEach((manager) => {
+      const key = managerKey(manager.name);
+      if (!key || seen.has(key)) return;
+      ordered.push(manager);
+      seen.add(key);
+    });
+
+  return ordered;
+};
+
+const activeDeadline = (data, week) => {
+  const deadlines = data && data.pickQueue && data.pickQueue.deadlines;
+  const value = deadlines && (deadlines[String(week)] || deadlines[week]);
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+};
+
+export const deriveQueueState = (data, now = new Date()) => {
+  if (!data || !Array.isArray(data.managers)) {
+    throw new QueueError(502, 'invalid_pool_data', 'The live pool data is unavailable.');
+  }
+
+  const config = data.pickQueue || {};
+  const activeWeek = Number(config.activeWeek || 1);
+  const enabled = config.enabled === true;
+  const deadline = activeDeadline(data, activeWeek);
+  const nowTimestamp = now instanceof Date ? now.getTime() : new Date(now).getTime();
+  const deadlineTimestamp = deadline ? Date.parse(deadline) : null;
+  const locked = Boolean(deadlineTimestamp && Number.isFinite(nowTimestamp) && nowTimestamp >= deadlineTimestamp);
+  const orderedManagers = normalizeOrder(data);
+  const eligibleManagers = orderedManagers.filter((manager) => !(manager.eliminated === true && manager.buyback !== true));
+  const firstWaitingIndex = eligibleManagers.findIndex((manager) => {
+    const pick = findWeekPick(manager, activeWeek);
+    return !String(pick && pick.team || '').trim();
+  });
+  const currentManager = firstWaitingIndex >= 0 ? eligibleManagers[firstWaitingIndex] : null;
+  const currentKey = managerKey(currentManager && currentManager.name);
+  const eligibleKeys = new Set(eligibleManagers.map((manager) => managerKey(manager.name)));
+
+  const entries = orderedManagers.map((manager) => {
+    const key = managerKey(manager.name);
+    const pick = findWeekPick(manager, activeWeek);
+    const team = String(pick && pick.team || '').trim();
+    let status = 'waiting';
+    if (!eligibleKeys.has(key)) status = 'ineligible';
+    else if (team) status = 'picked';
+    else if (key === currentKey) status = 'current';
+    return {
+      position: orderedManagers.indexOf(manager) + 1,
+      name: manager.name,
+      teamLabel: manager.teamLabel || '',
+      status,
+      team: team || null
+    };
+  });
+
+  const usedTeams = new Set(
+    (currentManager && Array.isArray(currentManager.picks) ? currentManager.picks : [])
+      .filter((pick) => Number(pick && pick.week) !== activeWeek)
+      .map((pick) => String(pick && pick.team || '').trim().toLowerCase())
+      .filter(Boolean)
+  );
+
+  return {
+    season: Number(data.season),
+    enabled,
+    activeWeek,
+    deadline,
+    locked,
+    complete: eligibleManagers.length > 0 && !currentManager,
+    currentManager: currentManager ? {
+      name: currentManager.name,
+      teamLabel: currentManager.teamLabel || '',
+      position: firstWaitingIndex + 1,
+      total: eligibleManagers.length
+    } : null,
+    entries,
+    availableTeams: currentManager
+      ? NFL_TEAMS.filter((team) => !usedTeams.has(team.toLowerCase()))
+      : [],
+    lastUpdated: data.lastUpdated || null,
+    lastSubmission: config.lastSubmission || null
+  };
+};
+
+export const applySubmission = (data, submission, now = new Date()) => {
+  const state = deriveQueueState(data, now);
+  if (!state.enabled) {
+    throw new QueueError(409, 'queue_closed', 'Public pick submission is not open.');
+  }
+  if (state.locked) {
+    throw new QueueError(409, 'deadline_passed', 'The weekly pick deadline has passed.');
+  }
+  if (state.complete || !state.currentManager) {
+    throw new QueueError(409, 'queue_complete', `All eligible Week ${state.activeWeek} picks are in.`);
+  }
+
+  const requestedWeek = Number(submission && submission.week);
+  if (requestedWeek !== state.activeWeek) {
+    throw new QueueError(409, 'wrong_week', `Week ${state.activeWeek} is the active pick queue.`);
+  }
+
+  const requestedManager = String(submission && submission.manager || '').trim();
+  if (managerKey(requestedManager) !== managerKey(state.currentManager.name)) {
+    throw new QueueError(409, 'not_your_turn', `It is ${state.currentManager.name}'s turn.`);
+  }
+
+  const requestedTeamKey = String(submission && submission.team || '').trim().toLowerCase();
+  const team = TEAM_BY_KEY.get(requestedTeamKey);
+  if (!team) {
+    throw new QueueError(422, 'invalid_team', 'Choose a valid NFL team.');
+  }
+  if (!state.availableTeams.includes(team)) {
+    throw new QueueError(409, 'team_already_used', `${state.currentManager.name} already used ${team} in another week.`);
+  }
+
+  const updated = structuredClone(data);
+  const manager = updated.managers.find((candidate) => managerKey(candidate.name) === managerKey(state.currentManager.name));
+  const pick = findWeekPick(manager, state.activeWeek);
+  if (!pick) {
+    throw new QueueError(502, 'missing_week', `${state.currentManager.name} has no Week ${state.activeWeek} pick slot.`);
+  }
+  if (String(pick.team || '').trim()) {
+    throw new QueueError(409, 'pick_already_submitted', `${state.currentManager.name}'s pick is already recorded.`);
+  }
+
+  const submittedAt = (now instanceof Date ? now : new Date(now)).toISOString();
+  pick.team = team;
+  pick.result = null;
+  pick.submittedBy = 'public-pick-queue';
+  pick.submittedAt = submittedAt;
+  pick.lastUpdated = submittedAt;
+  updated.lastUpdated = submittedAt;
+  updated.pickQueue = {
+    ...(updated.pickQueue || {}),
+    lastSubmission: {
+      manager: manager.name,
+      week: state.activeWeek,
+      team,
+      submittedAt
+    }
+  };
+
+  return {
+    data: updated,
+    receipt: {
+      manager: manager.name,
+      week: state.activeWeek,
+      team,
+      submittedAt
+    },
+    queue: deriveQueueState(updated, now)
+  };
+};

--- a/worker/test/coordinator.test.mjs
+++ b/worker/test/coordinator.test.mjs
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { PickQueueCoordinator } from '../src/index.js';
+
+const buildData = () => ({
+  season: 2026,
+  pickQueue: {
+    enabled: true,
+    activeWeek: 1,
+    order: ['Weston', 'Jordan'],
+    deadlines: { '1': '2099-08-13T19:00:00-04:00' }
+  },
+  managers: ['Weston', 'Jordan'].map((name, index) => ({
+    name,
+    teamLabel: `${name} Team`,
+    lastYearRank: index + 1,
+    eliminated: false,
+    picks: [1, 2, 3].map((week) => ({ week, team: '', result: null }))
+  })),
+  gameResults: {},
+  lastUpdated: '2026-08-12T12:00:00.000Z'
+});
+
+const env = {
+  GIST_ID: 'test-gist',
+  GIST_TOKEN: 'test-token',
+  ALLOWED_ORIGINS: 'https://enjoinick.github.io'
+};
+
+const submissionRequest = (manager, team) => new Request('https://worker.example/pick-queue', {
+  method: 'POST',
+  headers: {
+    Origin: 'https://enjoinick.github.io',
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({ manager, week: 1, team })
+});
+
+test('coordinator serializes simultaneous valid turns against the latest Gist state', async () => {
+  let liveData = buildData();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, options = {}) => {
+    if ((options.method || 'GET') === 'PATCH') {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      const payload = JSON.parse(options.body);
+      liveData = JSON.parse(payload.files['data.json'].content);
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      files: {
+        'data.json': {
+          content: JSON.stringify(liveData),
+          truncated: false
+        }
+      }
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  try {
+    const coordinator = new PickQueueCoordinator({}, env);
+    const [westonResponse, jordanResponse] = await Promise.all([
+      coordinator.fetch(submissionRequest('Weston', 'Jacksonville Jaguars')),
+      coordinator.fetch(submissionRequest('Jordan', 'Buffalo Bills'))
+    ]);
+    assert.equal(westonResponse.status, 201);
+    assert.equal(jordanResponse.status, 201);
+    assert.equal(liveData.managers[0].picks[0].team, 'Jacksonville Jaguars');
+    assert.equal(liveData.managers[1].picks[0].team, 'Buffalo Bills');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('coordinator returns a conflict response for an out-of-order turn', async () => {
+  const liveData = buildData();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    files: {
+      'data.json': {
+        content: JSON.stringify(liveData),
+        truncated: false
+      }
+    }
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+  try {
+    const coordinator = new PickQueueCoordinator({}, env);
+    const response = await coordinator.fetch(submissionRequest('Jordan', 'Buffalo Bills'));
+    const payload = await response.json();
+    assert.equal(response.status, 409);
+    assert.equal(payload.error, 'not_your_turn');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/worker/test/logic.test.mjs
+++ b/worker/test/logic.test.mjs
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { applySubmission, deriveQueueState, QueueError } from '../src/logic.js';
+
+const order = ['Weston', 'Jordan', 'Josh', 'Chris', 'Austin', 'Matt', 'Kevin', 'Michael', 'Ryan', 'Nick'];
+const buildData = () => ({
+  season: 2026,
+  pickQueue: {
+    enabled: true,
+    activeWeek: 1,
+    order,
+    deadlines: { '1': '2026-08-13T19:00:00-04:00' }
+  },
+  managers: order.map((name, index) => ({
+    name,
+    teamLabel: `${name} Team`,
+    lastYearRank: index + 1,
+    eliminated: false,
+    picks: [1, 2, 3].map((week) => ({ week, team: '', result: null }))
+  })),
+  gameResults: {},
+  lastUpdated: '2026-08-12T12:00:00.000Z'
+});
+
+const beforeDeadline = new Date('2026-08-12T20:00:00.000Z');
+
+test('queue starts with the first configured manager', () => {
+  const state = deriveQueueState(buildData(), beforeDeadline);
+  assert.equal(state.currentManager.name, 'Weston');
+  assert.equal(state.currentManager.position, 1);
+  assert.equal(state.entries[0].status, 'current');
+});
+
+test('an accepted pick advances exactly one turn', () => {
+  const result = applySubmission(buildData(), {
+    manager: 'Weston',
+    week: 1,
+    team: 'Jacksonville Jaguars'
+  }, beforeDeadline);
+  assert.equal(result.receipt.manager, 'Weston');
+  assert.equal(result.data.managers[0].picks[0].team, 'Jacksonville Jaguars');
+  assert.equal(result.queue.currentManager.name, 'Jordan');
+  assert.equal(result.queue.entries[0].status, 'picked');
+  assert.equal(result.queue.entries[1].status, 'current');
+});
+
+test('out-of-order submissions are rejected', () => {
+  assert.throws(
+    () => applySubmission(buildData(), { manager: 'Jordan', week: 1, team: 'Buffalo Bills' }, beforeDeadline),
+    (error) => error instanceof QueueError && error.code === 'not_your_turn'
+  );
+});
+
+test('a manager cannot reuse a team from an earlier week', () => {
+  const data = buildData();
+  data.managers[0].picks[1].team = 'Jacksonville Jaguars';
+  assert.throws(
+    () => applySubmission(data, { manager: 'Weston', week: 1, team: 'Jacksonville Jaguars' }, beforeDeadline),
+    (error) => error instanceof QueueError && error.code === 'team_already_used'
+  );
+});
+
+test('eliminated managers are skipped unless buyback is active', () => {
+  const data = buildData();
+  data.managers[0].eliminated = true;
+  const state = deriveQueueState(data, beforeDeadline);
+  assert.equal(state.currentManager.name, 'Jordan');
+  assert.equal(state.entries[0].status, 'ineligible');
+});
+
+test('the deadline locks submissions', () => {
+  const afterDeadline = new Date('2026-08-13T23:00:01.000Z');
+  const state = deriveQueueState(buildData(), afterDeadline);
+  assert.equal(state.locked, true);
+  assert.throws(
+    () => applySubmission(buildData(), { manager: 'Weston', week: 1, team: 'Buffalo Bills' }, afterDeadline),
+    (error) => error instanceof QueueError && error.code === 'deadline_passed'
+  );
+});
+
+test('the queue reports completion after all eligible picks', () => {
+  const data = buildData();
+  data.managers.forEach((manager, index) => {
+    manager.picks[0].team = index % 2 ? 'Buffalo Bills' : 'Jacksonville Jaguars';
+  });
+  const state = deriveQueueState(data, beforeDeadline);
+  assert.equal(state.complete, true);
+  assert.equal(state.currentManager, null);
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "howboutit-picks",
+  "main": "src/index.js",
+  "compatibility_date": "2026-08-12",
+  "compatibility_flags": ["global_fetch_strictly_public"],
+  "workers_dev": true,
+  "preview_urls": true,
+  "vars": {
+    "SEASON": "2026",
+    "GIST_ID": "870a75b6f5a4a7797bc90e6eefdd90a3",
+    "ALLOWED_ORIGINS": "https://enjoinick.github.io,http://127.0.0.1:8765,http://localhost:8765"
+  },
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "PICK_QUEUE",
+        "class_name": "PickQueueCoordinator"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["PickQueueCoordinator"]
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- added a public, no-login weekly pick form that only shows the current manager
- added a confirmation step, queue progress, deadline messaging, and mobile layout
- added admin controls to open/close the queue and choose the active week
- added an explicit 2025 tiebreak turn order: Weston, Jordan, Josh, Chris, Austin, Matt, Kevin, Michael, Ryan, Nick
- added a Cloudflare Durable Object Worker that keeps the Gist token server-side and serializes submissions
- rejects out-of-order, invalid, duplicate-team, eliminated-manager, and late submissions
- added a local UI mock plus unit and concurrent-request tests
- advanced the service-worker cache

## Why
Managers previously sent their picks to the commissioner, who entered every selection manually. A public Gist token would be unsafe and browser-only ordering would be easy to bypass or race, so submissions now go through one authoritative serialized Worker.

## User impact
The current manager chooses and confirms one NFL team without logging in. After an accepted write, the Gist updates and the page advances to the next manager. Identity remains honor-system by design; the backend enforces turn order and pool rules.

## Validation
- 9 automated tests pass
- simultaneous Weston/Jordan requests serialize and both apply in order
- live Worker health returns 200
- live out-of-order Jordan request returns 409 and leaves Weston current
- live Gist reports Week 1, Weston first, 10 entries, 32 teams, and no submitted picks
- desktop and 390×844 mobile UI tested end to end with the local Worker mock
- Worker deploy bundle validated and deployed
- `git diff --check` passes