### PR TITLE
Fix Week 1 pick order

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Single-page React app (vanilla React via `<script>` in `index.html`) hosted on G
 - The public site never receives or stores a GitHub token. Pick submissions go to a Cloudflare Durable Object that serializes turns and writes to the Gist with a server-side secret.
 - Admin writes require a short-lived Gist-only token. The token is kept only in the open admin tab, is never written to `localStorage`, and is cleared after a successful save.
 - The admin validates unique manager names, unique tiebreak ranks from 1 through the manager count, and duplicate team picks before saving.
-- `data.json.pickQueue` controls the enabled state, active week, explicit turn order, and weekly deadlines. The admin can open/close the queue and advance its active week.
+- `data.json.pickQueue` controls the enabled state, active week, week-specific turn orders, and weekly deadlines. The admin can open/close the queue and advance its active week without changing another week’s order.
 - Fantasy ADP is configured for 2026 in `config.json`.
 
 ## Local Development

--- a/admin.html
+++ b/admin.html
@@ -183,12 +183,22 @@
           season: { type: 'integer', const: SEASON_YEAR },
           pickQueue: {
             type: 'object',
-            required: ['enabled', 'activeWeek', 'order', 'deadlines'],
+            required: ['enabled', 'activeWeek', 'orders', 'deadlines'],
             additionalProperties: true,
             properties: {
               enabled: { type: 'boolean' },
               activeWeek: { type: 'integer', minimum: 1, maximum: 3 },
               order: { type: 'array', minItems: 1, uniqueItems: true, items: { type: 'string', minLength: 1 } },
+              orders: {
+                type: 'object',
+                required: ['1', '2', '3'],
+                additionalProperties: {
+                  type: 'array',
+                  minItems: 1,
+                  uniqueItems: true,
+                  items: { type: 'string', minLength: 1 }
+                }
+              },
               deadlines: { type: 'object', additionalProperties: { type: 'string' } }
             }
           },
@@ -268,24 +278,32 @@
         });
 
         const queue = data && data.pickQueue;
-        if (queue && Array.isArray(queue.order)) {
+        if (queue) {
           const managerNames = new Set(poolManagers.map((manager) => String(manager && manager.name || '').trim().toLowerCase()));
-          const queueNames = new Set();
-          queue.order.forEach((name, index) => {
-            const key = String(name || '').trim().toLowerCase();
-            if (!managerNames.has(key)) {
-              errors.push({ instancePath: `/pickQueue/order/${index}`, message: `references unknown manager ${name}` });
-            }
-            if (queueNames.has(key)) {
-              errors.push({ instancePath: `/pickQueue/order/${index}`, message: `duplicates manager ${name}` });
-            }
-            queueNames.add(key);
-          });
-          poolManagers.forEach((manager) => {
-            const name = String(manager && manager.name || '').trim();
-            if (name && !queueNames.has(name.toLowerCase())) {
-              errors.push({ instancePath: '/pickQueue/order', message: `is missing manager ${name}` });
-            }
+          const orders = queue.orders && typeof queue.orders === 'object'
+            ? Object.entries(queue.orders)
+            : (Array.isArray(queue.order) ? [['default', queue.order]] : []);
+          orders.forEach(([week, order]) => {
+            if (!Array.isArray(order)) return;
+            const queueNames = new Set();
+            order.forEach((name, index) => {
+              const key = String(name || '').trim().toLowerCase();
+              const path = week === 'default' ? `/pickQueue/order/${index}` : `/pickQueue/orders/${week}/${index}`;
+              if (!managerNames.has(key)) {
+                errors.push({ instancePath: path, message: `references unknown manager ${name}` });
+              }
+              if (queueNames.has(key)) {
+                errors.push({ instancePath: path, message: `duplicates manager ${name}` });
+              }
+              queueNames.add(key);
+            });
+            poolManagers.forEach((manager) => {
+              const name = String(manager && manager.name || '').trim();
+              if (name && !queueNames.has(name.toLowerCase())) {
+                const path = week === 'default' ? '/pickQueue/order' : `/pickQueue/orders/${week}`;
+                errors.push({ instancePath: path, message: `is missing manager ${name}` });
+              }
+            });
           });
         }
 
@@ -558,6 +576,11 @@
             enabled: false,
             activeWeek: 1,
             order: fallbackOrder,
+            orders: {
+              '1': fallbackOrder,
+              '2': fallbackOrder,
+              '3': fallbackOrder
+            },
             deadlines: {},
             ...(completeData.pickQueue || {}),
             ...changes
@@ -823,10 +846,16 @@
         enabled: false,
         activeWeek: 1,
         order: fallbackQueueOrder,
+        orders: {
+          '1': fallbackQueueOrder,
+          '2': fallbackQueueOrder,
+          '3': fallbackQueueOrder
+        },
         deadlines: {},
         ...(completeData.pickQueue || {})
       };
       const activeQueueDeadline = pickQueueConfig.deadlines && pickQueueConfig.deadlines[String(pickQueueConfig.activeWeek)];
+      const activeQueueOrder = (pickQueueConfig.orders && pickQueueConfig.orders[String(pickQueueConfig.activeWeek)]) || pickQueueConfig.order || fallbackQueueOrder;
       
       return (
         <div className="min-h-screen p-4">
@@ -986,16 +1015,21 @@
               </div>
               <div className="mt-5">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-2">
-                  <span className="text-sm font-semibold">Turn order</span>
+                  <span className="text-sm font-semibold">Week {pickQueueConfig.activeWeek} turn order</span>
                   <button
-                    onClick={() => updatePickQueue({ order: fallbackQueueOrder })}
+                    onClick={() => updatePickQueue({
+                      orders: {
+                        ...(pickQueueConfig.orders || {}),
+                        [String(pickQueueConfig.activeWeek)]: fallbackQueueOrder
+                      }
+                    })}
                     className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-sm"
                   >
-                    Use 2025 tiebreak order
+                    Use tiebreak order for Week {pickQueueConfig.activeWeek}
                   </button>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {pickQueueConfig.order.map((name, index) => (
+                  {activeQueueOrder.map((name, index) => (
                     <span key={`${name}-${index}`} className="px-3 py-1 rounded-full bg-purple-600/40 border border-purple-300/20 text-sm">
                       {index + 1}. {name}
                     </span>

--- a/data.json
+++ b/data.json
@@ -4,17 +4,55 @@
     "enabled": true,
     "activeWeek": 1,
     "order": [
-      "Weston",
-      "Jordan",
-      "Josh",
-      "Chris",
-      "Austin",
-      "Matt",
-      "Kevin",
-      "Michael",
+      "Nick",
       "Ryan",
-      "Nick"
+      "Michael",
+      "Kevin",
+      "Matt",
+      "Austin",
+      "Chris",
+      "Josh",
+      "Jordan",
+      "Weston"
     ],
+    "orders": {
+      "1": [
+        "Nick",
+        "Ryan",
+        "Michael",
+        "Kevin",
+        "Matt",
+        "Austin",
+        "Chris",
+        "Josh",
+        "Jordan",
+        "Weston"
+      ],
+      "2": [
+        "Weston",
+        "Jordan",
+        "Josh",
+        "Chris",
+        "Austin",
+        "Matt",
+        "Kevin",
+        "Michael",
+        "Ryan",
+        "Nick"
+      ],
+      "3": [
+        "Weston",
+        "Jordan",
+        "Josh",
+        "Chris",
+        "Austin",
+        "Matt",
+        "Kevin",
+        "Michael",
+        "Ryan",
+        "Nick"
+      ]
+    },
     "deadlines": {
       "1": "2026-08-13T19:00:00-04:00",
       "2": "2026-08-20T20:00:00-04:00",
@@ -73,7 +111,7 @@
     },
     {
       "name": "Michael",
-      "teamLabel": "The Sacks Kingdom",
+      "teamLabel": "Nut Sacks",
       "lastYearRank": 8,
       "picks": [
         {

--- a/index.html
+++ b/index.html
@@ -484,7 +484,7 @@
       const jokes = useMemo(() => [
         "Kevin (Check My Balls) — Kevin named the team Check My Balls, which is a lot of confidence for a roster with no visible toughness. Every Sunday he opens the injury report like WebMD: already convinced something is swollen and somehow blaming the commissioner.",
         "Jordan (GRAVEDIGGER) — GRAVEDIGGER sounds terrifying until you realize the graves are for players Jordan drafted two rounds early. He doesn’t bury opponents; he holds a tasteful little service for his projections every Monday.",
-        "Michael (The Sacks Kingdom) — Michael replaced Will and immediately founded The Sacks Kingdom. Buddy, that’s not a dynasty—it’s a medieval Hooters with worse pass protection and a Burger King crown.",
+        "Michael (Nut Sacks) — Michael replaced Will, renamed the team Nut Sacks, and somehow made the league’s injury report sound like a medical emergency at a gas station.",
         "Ryan (Quail Man SWAG) — Quail Man SWAG is the only team name wearing tighty-whities over khakis. Ryan’s draft strategy is pure Nickelodeon: loud colors, no adult supervision, cancelled before the playoffs.",
         "Nick (Allen’s Dirty Brown Kupp) — Nick’s team name sounds less like fantasy football and more like evidence being sealed in a plastic bag. Even autocorrect looked at it and said, ‘Nope, I’m not getting subpoenaed.’",
         "Chris (Hello Naber!) — Hello Naber! has the energy of a dad learning one rookie’s name and yelling it across Costco. Chris says ‘sleeper’ like he discovered fire, then drafts the guy everybody ranked 14th.",

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Minimal service worker for installability and basic offline support */
-const CACHE_NAME = 'survivor-pool-v4-20260812';
+const CACHE_NAME = 'survivor-pool-v5-20260812';
 const ASSETS = [
   './',
   './index.html',

--- a/worker/src/logic.js
+++ b/worker/src/logic.js
@@ -26,12 +26,14 @@ const findWeekPick = (manager, week) =>
   (Array.isArray(manager && manager.picks) ? manager.picks : [])
     .find((pick) => Number(pick && pick.week) === Number(week));
 
-const normalizeOrder = (data) => {
+const normalizeOrder = (data, week) => {
   const managers = Array.isArray(data && data.managers) ? data.managers : [];
   const managersByKey = new Map(managers.map((manager) => [managerKey(manager.name), manager]));
-  const configured = Array.isArray(data && data.pickQueue && data.pickQueue.order)
-    ? data.pickQueue.order
-    : [];
+  const queue = data && data.pickQueue || {};
+  const weekOrder = queue.orders && queue.orders[String(week)];
+  const configured = Array.isArray(weekOrder)
+    ? weekOrder
+    : (Array.isArray(queue.order) ? queue.order : []);
   const ordered = [];
   const seen = new Set();
 
@@ -75,7 +77,7 @@ export const deriveQueueState = (data, now = new Date()) => {
   const nowTimestamp = now instanceof Date ? now.getTime() : new Date(now).getTime();
   const deadlineTimestamp = deadline ? Date.parse(deadline) : null;
   const locked = Boolean(deadlineTimestamp && Number.isFinite(nowTimestamp) && nowTimestamp >= deadlineTimestamp);
-  const orderedManagers = normalizeOrder(data);
+  const orderedManagers = normalizeOrder(data, activeWeek);
   const eligibleManagers = orderedManagers.filter((manager) => !(manager.eliminated === true && manager.buyback !== true));
   const firstWaitingIndex = eligibleManagers.findIndex((manager) => {
     const pick = findWeekPick(manager, activeWeek);

--- a/worker/test/logic.test.mjs
+++ b/worker/test/logic.test.mjs
@@ -31,6 +31,19 @@ test('queue starts with the first configured manager', () => {
   assert.equal(state.entries[0].status, 'current');
 });
 
+test('the active week selects its own configured order', () => {
+  const data = buildData();
+  data.pickQueue.activeWeek = 2;
+  data.pickQueue.orders = {
+    '1': order,
+    '2': ['Nick', 'Ryan', 'Michael', 'Kevin', 'Matt', 'Austin', 'Chris', 'Josh', 'Jordan', 'Weston']
+  };
+  const state = deriveQueueState(data, beforeDeadline);
+  assert.equal(state.currentManager.name, 'Nick');
+  assert.equal(state.entries[0].name, 'Nick');
+  assert.equal(state.entries.at(-1).name, 'Weston');
+});
+
 test('an accepted pick advances exactly one turn', () => {
   const result = applySubmission(buildData(), {
     manager: 'Weston',


### PR DESCRIPTION
## What changed

- Set Week 1 to Nick, Ryan, Michael, Kevin, Matt, Austin, Chris, Josh, Jordan, and Weston.
- Rename Michael’s team to **Nut Sacks** everywhere it appears, including the joke ticker.
- Add independent pick orders for Weeks 1–3 so changing the current week no longer overwrites future weeks.
- Update the admin queue panel and data validation for week-specific orders.
- Bump the service-worker cache so returning visitors receive the new UI.

## Why

The public queue was using the prior-season tiebreak order instead of the supplied Week 1 order. The live queue had zero submitted picks, so correcting the order does not move or overwrite any existing selection.

## Validation

- `npm test` (10 tests passed)
- `npm run check`
- `git diff --check`
- Local browser verification of the public queue and admin panel
- Live Worker/Gist verification: Week 1 begins with Nick and contains zero submitted picks
