### PR TITLE
Align roster and ranking rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Single-page React app (vanilla React via `<script>` in `index.html`) hosted on G
 ## 2026 Season
 
 - The active pool covers official preseason Weeks 1-3, August 13-29, 2026. The standalone Hall of Fame Game is excluded.
-- `data.json` contains the ten 2026 managers. Their unique `lastYearRank` values (1 is best) are the agreed 2025 tiebreak order.
+- `data.json` contains the ten 2026 managers. Their unique `lastYearRank` values (1 is best) match the supplied 2025 league finish and are the final rules tiebreaker.
 - The final 2025 Gist snapshot is preserved in `data-2025.json`.
 - Active data must contain `"season": 2026`. Until the configured Gist is updated for 2026, both pages ignore its 2025 data and safely use the repository's starter `data.json`.
 - After deployment, open `admin.html` and use **Save to Gist** once to initialize the Gist for 2026. Gist revision history preserves the prior version as an additional backup.
@@ -17,7 +17,7 @@ Single-page React app (vanilla React via `<script>` in `index.html`) hosted on G
 ## Current Features
 
 - Manual refresh is throttled to 15 seconds.
-- Draft ordering and elimination calculations are memoized.
+- Draft ordering and elimination calculations use the shared, tested `ranking.js` rules engine.
 - ESPN preseason scores refresh every two minutes with retry/backoff.
 - Picks lock at their explicit Eastern Time kickoff.
 - Audio assets lazy-load and a global mute preference persists in `localStorage`.
@@ -30,7 +30,7 @@ Single-page React app (vanilla React via `<script>` in `index.html`) hosted on G
 - The public site never receives or stores a GitHub token. Pick submissions go to a Cloudflare Durable Object that serializes turns and writes to the Gist with a server-side secret.
 - Admin writes require a short-lived Gist-only token. The token is kept only in the open admin tab, is never written to `localStorage`, and is cleared after a successful save.
 - The admin validates unique manager names, unique tiebreak ranks from 1 through the manager count, and duplicate team picks before saving.
-- `data.json.pickQueue` controls the enabled state, active week, week-specific turn orders, and weekly deadlines. The admin can open/close the queue and advance its active week without changing another week’s order.
+- `data.json.pickQueue` controls the enabled state, active week, week-specific turn orders, ordering modes, and weekly deadlines. Week 1 uses the supplied fixed order; Weeks 2–3 automatically use standings through the prior completed week.
 - Fantasy ADP is configured for 2026 in `config.json`.
 
 ## Local Development
@@ -58,4 +58,5 @@ There is intentionally no manager login. Anyone with the pool URL can act for th
 
 - Times are displayed in Eastern Time.
 - Ties contribute zero and do not eliminate a manager.
-- Draft order is based on survival, cumulative margin, active/elimination-week margin, then the prior year's finish.
+- Draft order puts survivors first and managers eliminated in later weeks ahead of earlier eliminations. Managers eliminated in the same week are ordered only by that week’s margin, then last year’s finish. Multiple survivors retain the existing cumulative-winning-margin rule, followed by last year’s finish.
+- A buyback protects one loss; a later loss still eliminates that manager.

--- a/admin.html
+++ b/admin.html
@@ -9,6 +9,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" integrity="sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1" crossorigin="anonymous"></script>
+  <script src="ranking.js"></script>
   <!-- Babel Standalone enables JSX in the browser -->
   <script src="https://unpkg.com/@babel/standalone@7.28.5/babel.min.js" integrity="sha384-mP9sW+eK08VvAmlxEkn9Kn6egvKFtnFEfW7/u9feUWAIoTvnYAzT4NwsskP+uWUd" crossorigin="anonymous"></script>
   <!-- Font Awesome for icons -->
@@ -183,7 +184,7 @@
           season: { type: 'integer', const: SEASON_YEAR },
           pickQueue: {
             type: 'object',
-            required: ['enabled', 'activeWeek', 'orders', 'deadlines'],
+            required: ['enabled', 'activeWeek', 'orders', 'orderModes', 'deadlines'],
             additionalProperties: true,
             properties: {
               enabled: { type: 'boolean' },
@@ -198,6 +199,11 @@
                   uniqueItems: true,
                   items: { type: 'string', minLength: 1 }
                 }
+              },
+              orderModes: {
+                type: 'object',
+                required: ['1', '2', '3'],
+                additionalProperties: { enum: ['manual', 'standings'] }
               },
               deadlines: { type: 'object', additionalProperties: { type: 'string' } }
             }
@@ -470,13 +476,27 @@
         }
       };
       
+      const syncComputedManagerState = (poolManagers) => poolManagers.map((manager) => {
+        const standing = SurvivorRanking.analyzeManager(manager, {
+          totalWeeks: 3,
+          throughWeek: 3,
+          activeWeek: Number((completeData.pickQueue && completeData.pickQueue.activeWeek) || 1)
+        });
+        return {
+          ...manager,
+          eliminated: standing.isEliminated,
+          marginOfVictory: standing.totalMargin,
+          ...(standing.eliminationWeek ? { eliminationWeek: standing.eliminationWeek } : { eliminationWeek: null })
+        };
+      });
+
       const handlePickChange = (managerIndex, weekIndex, value) => {
         // Prevent duplicate team picks for the same manager
         if (value && managers[managerIndex].picks.some((p, idx) => idx !== weekIndex && p.team === value)) {
           showNotification('This team is already used in another week for this manager', 'error');
           return;
         }
-        const updatedManagers = [...managers];
+        const updatedManagers = structuredClone(managers);
         updatedManagers[managerIndex].picks[weekIndex] = {
           ...updatedManagers[managerIndex].picks[weekIndex],
           team: value,
@@ -488,7 +508,7 @@
       };
       
       const handleResultChange = (managerIndex, weekIndex, value) => {
-        const updatedManagers = [...managers];
+        const updatedManagers = structuredClone(managers);
         updatedManagers[managerIndex].picks[weekIndex] = {
           ...updatedManagers[managerIndex].picks[weekIndex],
           result: value,
@@ -496,21 +516,13 @@
           lastUpdated: new Date().toISOString()
         };
         
-        // Update elimination status
-        if (value === 'L') {
-          updatedManagers[managerIndex].eliminated = true;
-        } else {
-          // Check if manager has any other losses
-          const hasLoss = updatedManagers[managerIndex].picks.some(p => p.result === 'L');
-          updatedManagers[managerIndex].eliminated = hasLoss;
-        }
-        
-        setManagers(updatedManagers);
-        updateJsonData(updatedManagers);
+        const computedManagers = syncComputedManagerState(updatedManagers);
+        setManagers(computedManagers);
+        updateJsonData(computedManagers);
       };
       
       const handleManagerInfoChange = (managerIndex, field, value) => {
-        const updatedManagers = [...managers];
+        const updatedManagers = structuredClone(managers);
         if (field === 'lastYearRank') {
           updatedManagers[managerIndex][field] = parseInt(value);
         } else if (field === 'carryMargin') {
@@ -518,19 +530,18 @@
           updatedManagers[managerIndex][field] = Number.isFinite(num) ? num : 0;
         } else if (field === 'buyback') {
           updatedManagers[managerIndex][field] = !!value;
-          if (value === true) {
-            // Keep admin UI consistent: show as alive when buyback is active
-            updatedManagers[managerIndex].eliminated = false;
-          }
         } else {
           updatedManagers[managerIndex][field] = value;
         }
-        setManagers(updatedManagers);
-        updateJsonData(updatedManagers);
+        const computedManagers = field === 'buyback' || field === 'carryMargin'
+          ? syncComputedManagerState(updatedManagers)
+          : updatedManagers;
+        setManagers(computedManagers);
+        updateJsonData(computedManagers);
       };
       
       const handleMarginChange = (managerIndex, weekIndex, margin) => {
-        const updatedManagers = [...managers];
+        const updatedManagers = structuredClone(managers);
         updatedManagers[managerIndex].picks[weekIndex] = {
           ...updatedManagers[managerIndex].picks[weekIndex],
           margin: margin,
@@ -538,17 +549,9 @@
           lastUpdated: new Date().toISOString()
         };
         
-        // Recalculate total margin of victory
-        let totalMargin = 0;
-        updatedManagers[managerIndex].picks.forEach(pick => {
-          if (pick.result === 'W' && pick.margin) {
-            totalMargin += pick.margin;
-          }
-        });
-        updatedManagers[managerIndex].marginOfVictory = totalMargin;
-        
-        setManagers(updatedManagers);
-        updateJsonData(updatedManagers);
+        const computedManagers = syncComputedManagerState(updatedManagers);
+        setManagers(computedManagers);
+        updateJsonData(computedManagers);
       };
       
       const updateJsonData = (updatedManagers) => {
@@ -580,6 +583,11 @@
               '1': fallbackOrder,
               '2': fallbackOrder,
               '3': fallbackOrder
+            },
+            orderModes: {
+              '1': 'manual',
+              '2': 'standings',
+              '3': 'standings'
             },
             deadlines: {},
             ...(completeData.pickQueue || {}),
@@ -705,9 +713,10 @@
       };
       
       const resetElimination = (managerIndex) => {
-        const updatedManagers = [...managers];
+        const updatedManagers = structuredClone(managers);
         updatedManagers[managerIndex].eliminated = false;
         updatedManagers[managerIndex].marginOfVictory = 0;
+        updatedManagers[managerIndex].eliminationWeek = null;
         
         // Reset all results
         updatedManagers[managerIndex].picks.forEach(pick => {
@@ -720,7 +729,7 @@
       };
       
       const resetPick = (managerIndex, weekIndex) => {
-        const updatedManagers = [...managers];
+        const updatedManagers = structuredClone(managers);
         updatedManagers[managerIndex].picks[weekIndex] = {
           ...updatedManagers[managerIndex].picks[weekIndex],
           team: '',
@@ -730,21 +739,9 @@
           lastUpdated: new Date().toISOString()
         };
         
-        // Recalculate total margin of victory
-        let totalMargin = 0;
-        updatedManagers[managerIndex].picks.forEach(pick => {
-          if (pick.result === 'W' && pick.margin) {
-            totalMargin += pick.margin;
-          }
-        });
-        updatedManagers[managerIndex].marginOfVictory = totalMargin;
-        
-        // Update elimination status
-        const hasLoss = updatedManagers[managerIndex].picks.some(p => p.result === 'L');
-        updatedManagers[managerIndex].eliminated = hasLoss;
-        
-        setManagers(updatedManagers);
-        updateJsonData(updatedManagers);
+        const computedManagers = syncComputedManagerState(updatedManagers);
+        setManagers(computedManagers);
+        updateJsonData(computedManagers);
         showNotification('Weekly pick reset successfully', 'success');
       };
       
@@ -851,11 +848,21 @@
           '2': fallbackQueueOrder,
           '3': fallbackQueueOrder
         },
+        orderModes: {
+          '1': 'manual',
+          '2': 'standings',
+          '3': 'standings'
+        },
         deadlines: {},
         ...(completeData.pickQueue || {})
       };
       const activeQueueDeadline = pickQueueConfig.deadlines && pickQueueConfig.deadlines[String(pickQueueConfig.activeWeek)];
-      const activeQueueOrder = (pickQueueConfig.orders && pickQueueConfig.orders[String(pickQueueConfig.activeWeek)]) || pickQueueConfig.order || fallbackQueueOrder;
+      const activeQueueMode = (pickQueueConfig.orderModes && pickQueueConfig.orderModes[String(pickQueueConfig.activeWeek)]) || 'manual';
+      const automaticQueueOrder = SurvivorRanking.orderForPickWeek(managers, pickQueueConfig.activeWeek, { totalWeeks: 3 })
+        .map((manager) => manager.name);
+      const activeQueueOrder = activeQueueMode === 'standings'
+        ? automaticQueueOrder
+        : ((pickQueueConfig.orders && pickQueueConfig.orders[String(pickQueueConfig.activeWeek)]) || pickQueueConfig.order || fallbackQueueOrder);
       
       return (
         <div className="min-h-screen p-4">
@@ -1015,18 +1022,25 @@
               </div>
               <div className="mt-5">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-2">
-                  <span className="text-sm font-semibold">Week {pickQueueConfig.activeWeek} turn order</span>
-                  <button
-                    onClick={() => updatePickQueue({
-                      orders: {
-                        ...(pickQueueConfig.orders || {}),
-                        [String(pickQueueConfig.activeWeek)]: fallbackQueueOrder
-                      }
-                    })}
-                    className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-sm"
-                  >
-                    Use tiebreak order for Week {pickQueueConfig.activeWeek}
-                  </button>
+                  <div>
+                    <span className="text-sm font-semibold">Week {pickQueueConfig.activeWeek} turn order</span>
+                    <span className={`ml-2 px-2 py-1 rounded-full text-xs ${activeQueueMode === 'standings' ? 'bg-emerald-600/60' : 'bg-indigo-600/60'}`}>
+                      {activeQueueMode === 'standings' ? 'Automatic from prior-week standings' : 'Fixed manual order'}
+                    </span>
+                  </div>
+                  {activeQueueMode !== 'standings' && (
+                    <button
+                      onClick={() => updatePickQueue({
+                        orders: {
+                          ...(pickQueueConfig.orders || {}),
+                          [String(pickQueueConfig.activeWeek)]: fallbackQueueOrder
+                        }
+                      })}
+                      className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 rounded-lg text-sm"
+                    >
+                      Use last-year finish for Week {pickQueueConfig.activeWeek}
+                    </button>
+                  )}
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {activeQueueOrder.map((name, index) => (
@@ -1036,7 +1050,7 @@
                   ))}
                 </div>
               </div>
-              <p className="text-xs text-purple-300 mt-4">Save to Gist after changing these controls. Closing the queue takes effect as soon as the Gist save completes.</p>
+              <p className="text-xs text-purple-300 mt-4">Week 1 stays fixed to the supplied order. Weeks 2–3 automatically rank eligible survivors from completed prior weeks. Save to Gist after changing these controls.</p>
             </section>
             
             {/* Manager Cards */}

--- a/data.json
+++ b/data.json
@@ -53,6 +53,11 @@
         "Nick"
       ]
     },
+    "orderModes": {
+      "1": "manual",
+      "2": "standings",
+      "3": "standings"
+    },
     "deadlines": {
       "1": "2026-08-13T19:00:00-04:00",
       "2": "2026-08-20T20:00:00-04:00",
@@ -64,7 +69,7 @@
     {
       "name": "Kevin",
       "teamLabel": "Check My Balls",
-      "lastYearRank": 7,
+      "lastYearRank": 4,
       "picks": [
         {
           "week": 1,
@@ -87,8 +92,8 @@
     },
     {
       "name": "Jordan",
-      "teamLabel": "GRAVEDIGGER",
-      "lastYearRank": 2,
+      "teamLabel": "Jordan's Scary Team",
+      "lastYearRank": 9,
       "picks": [
         {
           "week": 1,
@@ -112,7 +117,7 @@
     {
       "name": "Michael",
       "teamLabel": "Nut Sacks",
-      "lastYearRank": 8,
+      "lastYearRank": 3,
       "picks": [
         {
           "week": 1,
@@ -135,8 +140,8 @@
     },
     {
       "name": "Ryan",
-      "teamLabel": "Quail Man SWAG",
-      "lastYearRank": 9,
+      "teamLabel": "RIP Doug Martin",
+      "lastYearRank": 2,
       "picks": [
         {
           "week": 1,
@@ -159,8 +164,8 @@
     },
     {
       "name": "Nick",
-      "teamLabel": "Allen's Dirty Brown Kupp",
-      "lastYearRank": 10,
+      "teamLabel": "Bake Her Lamb Raw",
+      "lastYearRank": 1,
       "picks": [
         {
           "week": 1,
@@ -183,8 +188,8 @@
     },
     {
       "name": "Chris",
-      "teamLabel": "Hello Naber!",
-      "lastYearRank": 4,
+      "teamLabel": "Gibbs Me That W 🖕🏻",
+      "lastYearRank": 7,
       "picks": [
         {
           "week": 1,
@@ -208,7 +213,7 @@
     {
       "name": "Josh",
       "teamLabel": "S K",
-      "lastYearRank": 3,
+      "lastYearRank": 8,
       "picks": [
         {
           "week": 1,
@@ -232,7 +237,7 @@
     {
       "name": "Weston",
       "teamLabel": "Robert DUUUVAL",
-      "lastYearRank": 1,
+      "lastYearRank": 10,
       "picks": [
         {
           "week": 1,
@@ -256,7 +261,7 @@
     {
       "name": "Matt",
       "teamLabel": "DELTA 8",
-      "lastYearRank": 6,
+      "lastYearRank": 5,
       "picks": [
         {
           "week": 1,
@@ -279,8 +284,8 @@
     },
     {
       "name": "Austin",
-      "teamLabel": "Honey Baked Lamb",
-      "lastYearRank": 5,
+      "teamLabel": "The Giants Graveyard",
+      "lastYearRank": 6,
       "picks": [
         {
           "week": 1,
@@ -307,5 +312,5 @@
     "week2": [],
     "week3": []
   },
-  "lastUpdated": "2026-08-12T19:13:54.228Z"
+  "lastUpdated": "2026-08-12T21:07:15.813Z"
 }

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" integrity="sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1" crossorigin="anonymous"></script>
   <!-- Chart.js for rendering bar charts -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" integrity="sha384-e6nUZLBkQ86NJ6TVVKAeSaK8jWa3NhkYWZFomE39AvDbQWeie9PlQqM3pmYW5d1g" crossorigin="anonymous"></script>
+  <script src="ranking.js"></script>
   <!-- Babel Standalone enables JSX in the browser -->
   <script src="https://unpkg.com/@babel/standalone@7.28.5/babel.min.js" integrity="sha384-mP9sW+eK08VvAmlxEkn9Kn6egvKFtnFEfW7/u9feUWAIoTvnYAzT4NwsskP+uWUd" crossorigin="anonymous"></script>
   <!-- Font Awesome for icons -->
@@ -227,7 +228,7 @@
       const initViewApplied = useRef(false);
       const [openWeeks, setOpenWeeks] = useState(new Set()); // mobile: which schedule weeks are expanded
       const joshAudioRef = useRef(null); // easter egg audio ref
-      const jordanAudioRef = useRef(null); // easter egg audio ref for Jordan (GRAVEDIGGER)
+      const jordanAudioRef = useRef(null); // easter egg audio ref for Jordan
       const westonAudioRef = useRef(null); // easter egg audio ref for Weston (DUUUVALL)
       const ryanAudioRef = useRef(null); // easter egg audio ref for Ryan (Opposite of Adults rmx)
       // Global audio mute toggle (persisted)
@@ -482,16 +483,16 @@
       const tickerTrackRef = useRef(null);
       const [tickerDuration, setTickerDuration] = useState(20); // seconds
       const jokes = useMemo(() => [
-        "Kevin (Check My Balls) — Kevin named the team Check My Balls, which is a lot of confidence for a roster with no visible toughness. Every Sunday he opens the injury report like WebMD: already convinced something is swollen and somehow blaming the commissioner.",
-        "Jordan (GRAVEDIGGER) — GRAVEDIGGER sounds terrifying until you realize the graves are for players Jordan drafted two rounds early. He doesn’t bury opponents; he holds a tasteful little service for his projections every Monday.",
-        "Michael (Nut Sacks) — Michael replaced Will, renamed the team Nut Sacks, and somehow made the league’s injury report sound like a medical emergency at a gas station.",
-        "Ryan (Quail Man SWAG) — Quail Man SWAG is the only team name wearing tighty-whities over khakis. Ryan’s draft strategy is pure Nickelodeon: loud colors, no adult supervision, cancelled before the playoffs.",
-        "Nick (Allen’s Dirty Brown Kupp) — Nick’s team name sounds less like fantasy football and more like evidence being sealed in a plastic bag. Even autocorrect looked at it and said, ‘Nope, I’m not getting subpoenaed.’",
-        "Chris (Hello Naber!) — Hello Naber! has the energy of a dad learning one rookie’s name and yelling it across Costco. Chris says ‘sleeper’ like he discovered fire, then drafts the guy everybody ranked 14th.",
-        "Josh (S K) — Josh enters as S K: two mysterious initials and zero available explanations. It’s like a government agency, except the intelligence failure happens in Round 1.",
-        "Weston (Robert DUUUVAL) — Robert DUUUVAL is ten percent wordplay and ninety percent Jacksonville mating call. Say DUUUVAL three times and a man in jorts appears to explain why this is finally the Jaguars’ year.",
-        "Matt (DELTA 8) — Matt calls the team DELTA 8 because REGULAR CONFIDENCE was already taken. By pick five he’s staring at the draft board like it just asked him to operate heavy machinery.",
-        "Austin (Honey Baked Lamb) — Honey Baked Lamb sounds like Easter dinner made by a man who lost the recipe and blamed the oven. Austin’s roster is the same: smells promising, looks expensive, and somebody’s apologizing by halftime."
+        "Nick (Bake Her Lamb Raw) — Nick named the team like a cooking instruction whispered during a health-code violation. The roster will be served rare, overpriced, and somehow still blamed on the commissioner.",
+        "Ryan (RIP Doug Martin) — Ryan built a memorial team for Doug Martin, which is touching until you realize his draft strategy also died around 2017. Respectful service, terrible waiver priority.",
+        "Michael (Nut Sacks) — Michael replaced Will and immediately named the team Nut Sacks. That is less of a franchise identity and more of a phrase an urgent-care nurse makes you repeat quietly.",
+        "Kevin (Check My Balls) — Kevin turned a routine fantasy matchup into the sentence every doctor dreads hearing at a backyard barbecue. His roster gets examined weekly and the prognosis remains ‘questionable.’",
+        "Matt (DELTA 8) — Matt named the team DELTA 8 because making draft decisions completely sober felt too predictable. By Round 6, the queue is moving and he is reading the snack label like a contract.",
+        "Austin (The Giants Graveyard) — Austin’s Giants Graveyard has plenty of room, mostly because New York keeps delivering fresh material. The headstones are just old depth charts with the names crossed out.",
+        "Chris (Gibbs Me That W 🖕🏻) — Chris added the finger emoji so nobody would mistake this for a polite request. It is a bold demand from a roster that still needs Jahmyr Gibbs to do the group project alone.",
+        "Josh (S K) — Josh kept S K short because the full explanation would take longer than his playoff run. Two letters, ten roster spots, and somehow still no vowels or contingency plan.",
+        "Jordan (Jordan’s Scary Team) — Jordan called it Jordan’s Scary Team, the fantasy equivalent of a haunted house with the lights on. The real jump scare arrives when the projections update Sunday morning.",
+        "Weston (Robert DUUUVAL) — Weston’s team remains one celebrity pun away from a Jacksonville zoning dispute. Shout DUUUVAL three times and a man in jorts appears to defend a nine-win ceiling."
       ], []);
       // Build continuous stream (initially in given order); click will reshuffle
       const [streamJokes, setStreamJokes] = useState([]);
@@ -1033,199 +1034,55 @@
       /**
        * Calculate elimination week and draft order
        */
-      // Helper to derive elimination and week even if picks weren't persisted yet
+      const getManagerStanding = (mgr, overrides = {}) => {
+        const totalWeeks = preseasonSchedule.length || 3;
+        const { activeWeek } = computeCalendarState(preseasonSchedule);
+        return SurvivorRanking.analyzeManager(mgr, {
+          totalWeeks,
+          throughWeek: totalWeeks,
+          activeWeek,
+          outcomeForPick: (pick) => pick && pick.team ? getTeamOutcomeForWeek(pick.team, pick.week) : null,
+          ...overrides
+        });
+      };
+
       const deriveElimination = (mgr) => {
-        // Buyback override: allow manager to continue despite a recorded loss
-        if (mgr && mgr.buyback === true) {
-          return { isEliminated: false, week: null };
-        }
-        // Prefer LIVE outcomes: if any completed game is a non-tie loss for the picked team, eliminated.
-        for (const p of (mgr.picks || [])) {
-          if (!p.team) continue;
-          const outcome = getTeamOutcomeForWeek(p.team, p.week);
-          if (outcome && outcome.state === 'post' && !outcome.isWinner && !outcome.isTie) {
-            return { isEliminated: true, week: p.week };
-          }
-        }
-        // Fallback to stored explicit losses only if no live completed outcome available
-        const lossPick = (mgr.picks || []).find(p => p.result === 'L');
-        if (lossPick) return { isEliminated: true, week: lossPick.week };
-        return { isEliminated: false, week: null };
+        const standing = getManagerStanding(mgr);
+        return { isEliminated: standing.isEliminated, week: standing.eliminationWeek };
       };
 
-      // Margin for a specific week. Prefer LIVE final score margin when available,
-      // otherwise fall back to stored pick.margin. Positive when the picked team leads.
       const getWeekMargin = (mgr, week) => {
-        // Buyback carry margin: use fixed margin if provided (e.g., -7)
-        if (mgr && mgr.buyback === true && typeof mgr.carryMargin === 'number') {
-          return mgr.carryMargin;
-        }
-        const wk = Number(week);
-        if (!wk) return 0;
-        const pick = (mgr.picks || []).find(p => Number(p.week) === wk);
-        if (!pick) return 0;
-        if (pick.team) {
-          const outcome = getTeamOutcomeForWeek(pick.team, wk);
-          // Use live final margin if the game is completed
-          if (outcome && outcome.state === 'post') {
-            return (outcome.score - outcome.oppScore) || 0;
-          }
-        }
-        // Fallback to stored margin if present (covers manual overrides or persisted results)
-        if (typeof pick.margin === 'number') return pick.margin;
-        return 0;
+        const standing = getManagerStanding(mgr, { activeWeek: Number(week) });
+        const entry = standing.weeks.find((candidate) => candidate.week === Number(week));
+        return entry && entry.final ? entry.margin : 0;
       };
 
-      // Calculate cumulative margin from all winning weeks (live-reactive)
-      const getCumulativeMargin = (mgr) => {
-        if (!mgr || !mgr.picks) return 0;
-        
-        // Start with buyback carry margin if applicable
-        let totalMargin = 0;
-        if (mgr && mgr.buyback === true && typeof mgr.carryMargin === 'number') {
-          totalMargin = mgr.carryMargin;
-        } else if (mgr && mgr.buyback === true) {
-          // For managers who bought back but don't have carryMargin set, check for Cincinnati Bengals loss
-          const bengalsLoss = (mgr.picks || []).find(p => p.team === 'Cincinnati Bengals');
-          if (bengalsLoss) {
-            totalMargin = -7; // Known margin for Cincinnati Bengals loss in Week 1
-          }
-        }
-        
-        const derived = deriveElimination(mgr);
-        
-        // For eliminated managers, include wins up to elimination week
-        // AND include the elimination-week loss margin (negative).
-        if (derived.isEliminated) {
-          const elimWeekNum = Number(derived.week);
-          for (const pick of mgr.picks) {
-            const wk = Number(pick.week);
-            if (!wk || !pick.team) continue;
-            if (wk > elimWeekNum) continue;
+      const getCumulativeMargin = (mgr) => getManagerStanding(mgr).totalMargin;
 
-            const outcome = getTeamOutcomeForWeek(pick.team, wk);
-            let margin = 0;
-            let isWin = false;
-            let isLoss = false;
-
-            if (outcome && outcome.state === 'post') {
-              const diff = (outcome.score - outcome.oppScore) || 0; // perspective = picked team
-              isWin = outcome.isWinner && !outcome.isTie;
-              isLoss = !outcome.isWinner && !outcome.isTie;
-              margin = diff;
-            } else {
-              if (typeof pick.margin === 'number') margin = pick.margin;
-              isWin = pick.result === 'W';
-              isLoss = pick.result === 'L';
-            }
-
-            if (isWin) {
-              totalMargin += Math.max(0, margin);
-            } else if (isLoss && wk === elimWeekNum) {
-              // Add the negative loss margin from the elimination week
-              totalMargin += Math.min(0, margin);
-            }
-          }
-          return totalMargin;
-        }
-        
-        // For active managers, calculate cumulative wins
-        for (const pick of mgr.picks) {
-          const wk = Number(pick.week);
-          if (!wk || !pick.team) continue;
-          
-          // Check if this pick is a win (prefer live final over stored result)
-          const outcome = getTeamOutcomeForWeek(pick.team, wk);
-          let isWin = false;
-          let margin = 0;
-          
-          if (outcome && outcome.state === 'post') {
-            // Use live final result and margin
-            isWin = outcome.isWinner && !outcome.isTie;
-            margin = isWin ? ((outcome.score - outcome.oppScore) || 0) : 0;
-          } else {
-            // Fallback to stored result and margin
-            isWin = pick.result === 'W';
-            margin = (isWin && typeof pick.margin === 'number') ? pick.margin : 0;
-          }
-          
-          if (isWin) {
-            totalMargin += margin;
-          }
-        }
-        return totalMargin;
-      };
-
-      // Build a concise week-by-week margin breakdown matching getCumulativeMargin rules
       const getMarginBreakdown = (mgr) => {
-        if (!mgr || !Array.isArray(mgr.picks)) return 'No data';
-        const derived = deriveElimination(mgr);
-        const elimWeekNum = derived.isEliminated ? Number(derived.week) : null;
-        const picksSorted = mgr.picks.slice().sort((a,b) => (Number(a.week||0) - Number(b.week||0)));
-        let total = 0;
-        const lines = [];
-        for (const pick of picksSorted) {
-          const wk = Number(pick.week);
-          if (!wk || !pick.team) continue;
-          if (elimWeekNum && wk > elimWeekNum) continue;
-          const outcome = getTeamOutcomeForWeek(pick.team, wk);
-          let isTie = false, isWin = false, isLoss = false, diff = 0;
-          if (outcome && outcome.state === 'post') {
-            diff = (outcome.score - outcome.oppScore) || 0;
-            isTie = !!outcome.isTie;
-            isWin = outcome.isWinner && !isTie;
-            isLoss = !outcome.isWinner && !isTie;
-          } else {
-            if (typeof pick.margin === 'number') diff = pick.margin;
-            isWin = pick.result === 'W';
-            isLoss = pick.result === 'L';
-            isTie = pick.result === 'T';
-          }
-          if (derived.isEliminated) {
-            if (isWin) {
-              total += Math.max(0, diff);
-              lines.push(`W${wk} ${pick.team}: +${Math.max(0, diff)}`);
-            } else if (isLoss && wk === elimWeekNum) {
-              total += Math.min(0, diff);
-              lines.push(`W${wk} ${pick.team}: ${Math.min(0, diff)}`);
-            }
-          } else {
-            if (isWin) {
-              total += Math.max(0, diff);
-              lines.push(`W${wk} ${pick.team}: +${Math.max(0, diff)}`);
-            }
-          }
-        }
+        const standing = getManagerStanding(mgr);
+        const lines = standing.weeks
+          .filter((entry) => entry.final && entry.counted && entry.team)
+          .map((entry) => {
+            const marker = entry.buyback ? ' (buyback)' : '';
+            const margin = entry.margin > 0 ? `+${entry.margin}` : entry.margin;
+            return `W${entry.week} ${entry.team}: ${margin}${marker}`;
+          });
         if (lines.length === 0) return 'No completed margins yet';
-        lines.push(`Total: ${total}`);
+        lines.push(`Total: ${standing.totalMargin}`);
         return lines.join('\n');
       };
 
-      // Draft order per provided rules (live-reactive)
+      // Draft order per the published rules. Live finals take precedence over stored results.
       const computeDraftOrderLive = (mgrs) => {
-        const totalWeeks = preseasonSchedule.length || 0;
+        const totalWeeks = preseasonSchedule.length || 3;
         const { activeWeek } = computeCalendarState(preseasonSchedule);
-        const withKeys = mgrs.map(mgr => {
-          const derived = deriveElimination(mgr);
-          const eliminationWeek = derived.isEliminated ? Number(derived.week) : (totalWeeks + 1); // survivors rank highest
-          // For survivors, use the CURRENT active week's margin to rank winners of completed games above others
-          const tieWeek = derived.isEliminated ? Number(derived.week) : Number(activeWeek);
-          const weekMargin = getWeekMargin(mgr, tieWeek);
-          const cumulativeMargin = getCumulativeMargin(mgr);
-          return { ...mgr, eliminationWeek, weekMargin, cumulativeMargin };
+        return SurvivorRanking.rankManagers(mgrs, {
+          totalWeeks,
+          throughWeek: totalWeeks,
+          activeWeek,
+          outcomeForPick: (pick) => pick && pick.team ? getTeamOutcomeForWeek(pick.team, pick.week) : null
         });
-        return withKeys
-          .sort((a, b) => {
-            // 1) Later elimination week first (survivors have totalWeeks+1)
-            if (a.eliminationWeek !== b.eliminationWeek) return b.eliminationWeek - a.eliminationWeek;
-            // 2) Larger cumulative margin higher (primary tiebreaker)
-            if (a.cumulativeMargin !== b.cumulativeMargin) return b.cumulativeMargin - a.cumulativeMargin;
-            // 3) Larger week margin higher (secondary tiebreaker for current week performance)
-            if (a.weekMargin !== b.weekMargin) return b.weekMargin - a.weekMargin;
-            // 4) Better last year rank (smaller number is better)
-            return a.lastYearRank - b.lastYearRank;
-          })
-          .map((mgr, idx) => ({ ...mgr, draftOrder: idx + 1 }));
       };
 
       const orderedManagers = useMemo(() => computeDraftOrderLive(managers), [managers, games, preseasonSchedule]);
@@ -1333,10 +1190,10 @@
           }
           return;
         }
-        // Jordan easter egg: trigger on name or team label "GRAVEDIGGER"
+        // Jordan easter egg: trigger on manager name or current team label.
         const isJordan = mgr.name.trim().toLowerCase() === 'jordan';
-        const isGraveDigger = (mgr.teamLabel || '').trim().toLowerCase() === 'gravedigger';
-        if ((isJordan || isGraveDigger) && jordanAudioRef.current) {
+        const isJordanTeam = (mgr.teamLabel || '').trim().toLowerCase() === "jordan's scary team";
+        if ((isJordan || isJordanTeam) && jordanAudioRef.current) {
           try {
             pauseAllEggs();
             jordanAudioRef.current.currentTime = 0;
@@ -1849,6 +1706,8 @@
             </h2>
             <ul className="list-disc pl-5 space-y-1">
               <li><strong>Survivors first</strong>: Last manager standing gets #1 pick; other survivors follow (#2, #3, ...).</li>
+              <li><strong>Multiple survivors</strong>: Higher cumulative winning margin ranks higher, then last year’s finish.</li>
+              <li><strong>Different elimination weeks</strong>: The manager who survived longer ranks higher.</li>
               <li><strong>Same-week elimination</strong>: Higher <em>margin of victory that week</em> ranks higher.</li>
               <li><strong>Still tied</strong>: Higher <em>last year’s finish</em> ranks higher.</li>
               <li><strong>If all eliminated same week</strong>: Use that week’s margin, then last year’s finish.</li>

--- a/ranking.js
+++ b/ranking.js
@@ -1,0 +1,182 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  root.SurvivorRanking = api;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  const resultKey = (value) => {
+    const normalized = String(value || '').trim().toUpperCase();
+    return normalized === 'W' || normalized === 'L' || normalized === 'T' ? normalized : null;
+  };
+
+  const finiteNumber = (value, fallback = 0) => {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : fallback;
+  };
+
+  const weekNumber = (value) => {
+    const number = Number(value);
+    return Number.isInteger(number) && number > 0 ? number : null;
+  };
+
+  const normalizeOutcome = (pick, outcomeForPick) => {
+    const live = typeof outcomeForPick === 'function' ? outcomeForPick(pick) : null;
+    if (live && live.state === 'post') {
+      const score = finiteNumber(live.score);
+      const opponentScore = finiteNumber(live.oppScore);
+      const margin = score - opponentScore;
+      const isTie = live.isTie === true || margin === 0;
+      return {
+        final: true,
+        result: isTie ? 'T' : (margin > 0 ? 'W' : 'L'),
+        margin: isTie ? 0 : margin
+      };
+    }
+
+    const result = resultKey(pick && pick.result);
+    return {
+      final: result !== null,
+      result,
+      margin: result === 'T' ? 0 : finiteNumber(pick && pick.margin)
+    };
+  };
+
+  const analyzeManager = (manager, options = {}) => {
+    const totalWeeks = Math.max(1, finiteNumber(options.totalWeeks, 3));
+    const throughWeek = Math.max(0, finiteNumber(options.throughWeek, totalWeeks));
+    const activeWeek = Math.max(1, finiteNumber(options.activeWeek, Math.min(totalWeeks, throughWeek || 1)));
+    const picks = (Array.isArray(manager && manager.picks) ? manager.picks : [])
+      .filter((pick) => weekNumber(pick && pick.week) !== null)
+      .slice()
+      .sort((a, b) => Number(a.week) - Number(b.week));
+
+    const buybackEnabled = manager && manager.buyback === true;
+    const configuredBuybackWeek = weekNumber(manager && manager.buybackWeek);
+    let buybackUsed = false;
+    let protectedLossMargin = 0;
+    let winningMargin = 0;
+    let eliminationWeek = null;
+    let eliminationMargin = 0;
+    const weeks = [];
+
+    for (const pick of picks) {
+      const week = Number(pick.week);
+      if (week > throughWeek) continue;
+      const outcome = normalizeOutcome(pick, options.outcomeForPick);
+      const entry = {
+        week,
+        team: String(pick.team || '').trim(),
+        final: outcome.final,
+        result: outcome.result,
+        margin: outcome.margin,
+        buyback: false,
+        counted: false
+      };
+
+      if (!outcome.final || eliminationWeek !== null) {
+        weeks.push(entry);
+        continue;
+      }
+
+      if (outcome.result === 'W') {
+        winningMargin += Math.max(0, outcome.margin);
+        entry.counted = true;
+      } else if (outcome.result === 'L') {
+        const protectsThisLoss = buybackEnabled && !buybackUsed &&
+          (configuredBuybackWeek === null || configuredBuybackWeek === week);
+        if (protectsThisLoss) {
+          buybackUsed = true;
+          protectedLossMargin = Number.isFinite(Number(manager.carryMargin))
+            ? Number(manager.carryMargin)
+            : Math.min(0, outcome.margin);
+          entry.buyback = true;
+          entry.counted = true;
+        } else {
+          eliminationWeek = week;
+          eliminationMargin = Math.min(0, outcome.margin);
+          entry.counted = true;
+        }
+      }
+      weeks.push(entry);
+    }
+
+    // Backward-compatible support for an explicit manual elimination week.
+    if (eliminationWeek === null && manager && manager.eliminated === true && !buybackEnabled) {
+      const explicitWeek = weekNumber(manager.eliminationWeek);
+      if (explicitWeek !== null && explicitWeek <= throughWeek) {
+        const explicit = weeks.find((entry) => entry.week === explicitWeek);
+        // Never let a stale manual flag override a final win/tie or a newer live result.
+        if (!explicit || !explicit.final) {
+          eliminationWeek = explicitWeek;
+          eliminationMargin = explicit ? Math.min(0, explicit.margin) : 0;
+        }
+      }
+    }
+
+    const survivorMargin = winningMargin + (buybackUsed ? protectedLossMargin : 0);
+    const totalMargin = survivorMargin + (eliminationWeek !== null ? eliminationMargin : 0);
+    const activeEntry = weeks.find((entry) => entry.week === activeWeek);
+
+    return {
+      isEliminated: eliminationWeek !== null,
+      eliminationWeek,
+      eliminationMargin,
+      buybackUsed,
+      survivorMargin,
+      totalMargin,
+      activeWeekMargin: activeEntry && activeEntry.final ? activeEntry.margin : 0,
+      weeks
+    };
+  };
+
+  const rankManagers = (managers, options = {}) => {
+    const totalWeeks = Math.max(1, finiteNumber(options.totalWeeks, 3));
+    return (Array.isArray(managers) ? managers : [])
+      .map((manager, originalIndex) => {
+        const standing = analyzeManager(manager, options);
+        return {
+          ...manager,
+          ...standing,
+          originalIndex,
+          eliminationSortWeek: standing.isEliminated ? standing.eliminationWeek : totalWeeks + 1,
+          weekMargin: standing.isEliminated ? standing.eliminationMargin : standing.activeWeekMargin,
+          cumulativeMargin: standing.totalMargin
+        };
+      })
+      .sort((a, b) => {
+        // Survivors rank above eliminated managers; among eliminated managers, lasting longer wins.
+        if (a.eliminationSortWeek !== b.eliminationSortWeek) {
+          return b.eliminationSortWeek - a.eliminationSortWeek;
+        }
+
+        if (a.isEliminated && b.isEliminated) {
+          // The stated same-week rule deliberately ignores earlier cumulative margin.
+          if (a.eliminationMargin !== b.eliminationMargin) {
+            return b.eliminationMargin - a.eliminationMargin;
+          }
+        } else if (!a.isEliminated && !b.isEliminated) {
+          // Additional survivor ordering rule retained from the existing pool behavior.
+          if (a.survivorMargin !== b.survivorMargin) {
+            return b.survivorMargin - a.survivorMargin;
+          }
+        }
+
+        const rankDifference = finiteNumber(a.lastYearRank, 999) - finiteNumber(b.lastYearRank, 999);
+        if (rankDifference !== 0) return rankDifference;
+        return a.originalIndex - b.originalIndex;
+      })
+      .map((manager, index) => ({ ...manager, draftOrder: index + 1 }));
+  };
+
+  const orderForPickWeek = (managers, pickWeek, options = {}) => {
+    const week = Math.max(1, finiteNumber(pickWeek, 1));
+    return rankManagers(managers, {
+      ...options,
+      activeWeek: Math.max(1, week - 1),
+      throughWeek: Math.max(0, week - 1)
+    });
+  };
+
+  return Object.freeze({ analyzeManager, normalizeOutcome, orderForPickWeek, rankManagers });
+}));

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,10 @@
 /* Minimal service worker for installability and basic offline support */
-const CACHE_NAME = 'survivor-pool-v5-20260812';
+const CACHE_NAME = 'survivor-pool-v6-20260812';
 const ASSETS = [
   './',
   './index.html',
   './admin.html',
+  './ranking.js',
   './manifest.webmanifest',
   './favicon.svg',
   './icons/icon-192.svg',

--- a/worker/package.json
+++ b/worker/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test test/logic.test.mjs test/coordinator.test.mjs",
-    "check": "node --check src/index.js && node --check src/logic.js",
+    "test": "node --test test/logic.test.mjs test/coordinator.test.mjs test/ranking.test.mjs",
+    "check": "node --check src/index.js && node --check src/logic.js && node --check ../ranking.js",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy"
   },

--- a/worker/src/logic.js
+++ b/worker/src/logic.js
@@ -1,3 +1,5 @@
+import SurvivorRanking from '../../ranking.js';
+
 export const NFL_TEAMS = Object.freeze([
   'Arizona Cardinals', 'Atlanta Falcons', 'Baltimore Ravens', 'Buffalo Bills',
   'Carolina Panthers', 'Chicago Bears', 'Cincinnati Bengals', 'Cleveland Browns',
@@ -31,9 +33,10 @@ const normalizeOrder = (data, week) => {
   const managersByKey = new Map(managers.map((manager) => [managerKey(manager.name), manager]));
   const queue = data && data.pickQueue || {};
   const weekOrder = queue.orders && queue.orders[String(week)];
-  const configured = Array.isArray(weekOrder)
-    ? weekOrder
-    : (Array.isArray(queue.order) ? queue.order : []);
+  const orderMode = queue.orderModes && queue.orderModes[String(week)];
+  const configured = orderMode === 'standings' && Number(week) > 1
+    ? SurvivorRanking.orderForPickWeek(managers, week, { totalWeeks: 3 }).map((manager) => manager.name)
+    : (Array.isArray(weekOrder) ? weekOrder : (Array.isArray(queue.order) ? queue.order : []));
   const ordered = [];
   const seen = new Set();
 
@@ -78,7 +81,16 @@ export const deriveQueueState = (data, now = new Date()) => {
   const deadlineTimestamp = deadline ? Date.parse(deadline) : null;
   const locked = Boolean(deadlineTimestamp && Number.isFinite(nowTimestamp) && nowTimestamp >= deadlineTimestamp);
   const orderedManagers = normalizeOrder(data, activeWeek);
-  const eligibleManagers = orderedManagers.filter((manager) => !(manager.eliminated === true && manager.buyback !== true));
+  const priorWeek = Math.max(0, activeWeek - 1);
+  const eligibleManagers = orderedManagers.filter((manager) => {
+    const standing = SurvivorRanking.analyzeManager(manager, {
+      totalWeeks: 3,
+      throughWeek: priorWeek,
+      activeWeek: Math.max(1, priorWeek)
+    });
+    const manualElimination = manager.eliminated === true && manager.buyback !== true;
+    return !manualElimination && !standing.isEliminated;
+  });
   const firstWaitingIndex = eligibleManagers.findIndex((manager) => {
     const pick = findWeekPick(manager, activeWeek);
     return !String(pick && pick.team || '').trim();
@@ -117,7 +129,7 @@ export const deriveQueueState = (data, now = new Date()) => {
     activeWeek,
     deadline,
     locked,
-    complete: eligibleManagers.length > 0 && !currentManager,
+    complete: !currentManager,
     currentManager: currentManager ? {
       name: currentManager.name,
       teamLabel: currentManager.teamLabel || '',

--- a/worker/test/logic.test.mjs
+++ b/worker/test/logic.test.mjs
@@ -44,6 +44,19 @@ test('the active week selects its own configured order', () => {
   assert.equal(state.entries.at(-1).name, 'Weston');
 });
 
+test('future weeks automatically use prior-week standings and skip eliminated managers', () => {
+  const data = buildData();
+  data.pickQueue.activeWeek = 2;
+  data.pickQueue.orderModes = { '1': 'manual', '2': 'standings', '3': 'standings' };
+  data.managers.find((manager) => manager.name === 'Weston').picks[0] = { week: 1, team: 'Team A', result: 'W', margin: 2 };
+  data.managers.find((manager) => manager.name === 'Jordan').picks[0] = { week: 1, team: 'Team B', result: 'W', margin: 10 };
+  data.managers.find((manager) => manager.name === 'Josh').picks[0] = { week: 1, team: 'Team C', result: 'L', margin: -1 };
+  const state = deriveQueueState(data, beforeDeadline);
+  assert.equal(state.currentManager.name, 'Jordan');
+  assert.equal(state.entries[0].name, 'Jordan');
+  assert.equal(state.entries.find((entry) => entry.name === 'Josh').status, 'ineligible');
+});
+
 test('an accepted pick advances exactly one turn', () => {
   const result = applySubmission(buildData(), {
     manager: 'Weston',
@@ -99,4 +112,18 @@ test('the queue reports completion after all eligible picks', () => {
   const state = deriveQueueState(data, beforeDeadline);
   assert.equal(state.complete, true);
   assert.equal(state.currentManager, null);
+});
+
+test('the queue reports completion when no managers remain eligible', () => {
+  const data = buildData();
+  data.pickQueue.activeWeek = 2;
+  data.pickQueue.orderModes = { '1': 'manual', '2': 'standings', '3': 'standings' };
+  data.managers.forEach((manager) => {
+    manager.picks[0] = { week: 1, team: 'Team A', result: 'L', margin: -1 };
+    manager.eliminated = true;
+  });
+  const state = deriveQueueState(data, beforeDeadline);
+  assert.equal(state.complete, true);
+  assert.equal(state.currentManager, null);
+  assert.equal(state.entries.every((entry) => entry.status === 'ineligible'), true);
 });

--- a/worker/test/ranking.test.mjs
+++ b/worker/test/ranking.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import SurvivorRanking from '../../ranking.js';
+
+const pick = (week, result, margin) => ({ week, team: `Team ${week}`, result, margin });
+const manager = (name, lastYearRank, picks, extra = {}) => ({
+  name,
+  teamLabel: `${name} Team`,
+  lastYearRank,
+  picks,
+  eliminated: picks.some((entry) => entry.result === 'L'),
+  ...extra
+});
+
+const rank = (managers, options = {}) => SurvivorRanking.rankManagers(managers, {
+  totalWeeks: 3,
+  throughWeek: 3,
+  activeWeek: 3,
+  ...options
+});
+
+test('survivors rank before eliminated managers and later elimination ranks higher', () => {
+  const ranked = rank([
+    manager('Week 1 Exit', 1, [pick(1, 'L', -1)]),
+    manager('Survivor', 3, [pick(1, 'W', 1), pick(2, 'W', 1), pick(3, 'W', 1)]),
+    manager('Week 2 Exit', 2, [pick(1, 'W', 1), pick(2, 'L', -30)])
+  ]);
+  assert.deepEqual(ranked.map((entry) => entry.name), ['Survivor', 'Week 2 Exit', 'Week 1 Exit']);
+});
+
+test('same-week elimination uses that week margin before cumulative margin', () => {
+  const ranked = rank([
+    manager('Huge Earlier Win', 1, [pick(1, 'W', 50), pick(2, 'L', -10)]),
+    manager('Closer Loss', 9, [pick(1, 'W', 1), pick(2, 'L', -3)])
+  ]);
+  assert.deepEqual(ranked.map((entry) => entry.name), ['Closer Loss', 'Huge Earlier Win']);
+});
+
+test('last year finish breaks an equal same-week elimination margin', () => {
+  const ranked = rank([
+    manager('Prior Ninth', 9, [pick(1, 'L', -7)]),
+    manager('Prior Second', 2, [pick(1, 'L', -7)])
+  ]);
+  assert.deepEqual(ranked.map((entry) => entry.name), ['Prior Second', 'Prior Ninth']);
+});
+
+test('all eliminated in the same week are ordered by week margin then prior finish', () => {
+  const ranked = rank([
+    manager('Lost Big', 1, [pick(1, 'L', -20)]),
+    manager('Close Low Prior', 8, [pick(1, 'L', -2)]),
+    manager('Close High Prior', 3, [pick(1, 'L', -2)])
+  ]);
+  assert.deepEqual(ranked.map((entry) => entry.name), ['Close High Prior', 'Close Low Prior', 'Lost Big']);
+});
+
+test('survivors use cumulative winning margin then prior finish', () => {
+  const ranked = rank([
+    manager('Low Margin', 1, [pick(1, 'W', 2), pick(2, 'W', 1)]),
+    manager('High Margin', 10, [pick(1, 'W', 10), pick(2, 'W', 2)]),
+    manager('Tied Margin Better Prior', 4, [pick(1, 'W', 6), pick(2, 'W', 6)])
+  ]);
+  assert.deepEqual(ranked.map((entry) => entry.name), ['Tied Margin Better Prior', 'High Margin', 'Low Margin']);
+});
+
+test('ties contribute zero and do not eliminate a manager', () => {
+  const standing = SurvivorRanking.analyzeManager(
+    manager('Tie', 1, [pick(1, 'T', 12)]),
+    { totalWeeks: 3, throughWeek: 1, activeWeek: 1 }
+  );
+  assert.equal(standing.isEliminated, false);
+  assert.equal(standing.totalMargin, 0);
+  assert.equal(standing.weeks[0].margin, 0);
+});
+
+test('a live final result overrides a stale stored elimination flag', () => {
+  const standing = SurvivorRanking.analyzeManager(
+    manager('Corrected Live', 1, [pick(1, 'L', -3)], { eliminated: true, eliminationWeek: 1 }),
+    {
+      totalWeeks: 3,
+      throughWeek: 1,
+      activeWeek: 1,
+      outcomeForPick: () => ({ state: 'post', score: 24, oppScore: 17, isTie: false })
+    }
+  );
+  assert.equal(standing.isEliminated, false);
+  assert.equal(standing.survivorMargin, 7);
+});
+
+test('a buyback protects one loss but a later loss eliminates the manager', () => {
+  const standing = SurvivorRanking.analyzeManager(
+    manager('Buyback', 1, [pick(1, 'L', -7), pick(2, 'W', 10), pick(3, 'L', -4)], {
+      buyback: true,
+      carryMargin: -7
+    }),
+    { totalWeeks: 3, throughWeek: 3, activeWeek: 3 }
+  );
+  assert.equal(standing.buybackUsed, true);
+  assert.equal(standing.isEliminated, true);
+  assert.equal(standing.eliminationWeek, 3);
+  assert.equal(standing.eliminationMargin, -4);
+  assert.equal(standing.totalMargin, -1);
+});
+
+test('next-week pick order freezes standings through the prior week', () => {
+  const managers = [
+    manager('Eliminated', 1, [pick(1, 'L', -1), pick(2, 'W', 50)]),
+    manager('Small Win', 2, [pick(1, 'W', 3), pick(2, 'W', 50)]),
+    manager('Big Win', 3, [pick(1, 'W', 12), pick(2, 'L', -30)])
+  ];
+  const weekTwo = SurvivorRanking.orderForPickWeek(managers, 2, { totalWeeks: 3 });
+  assert.deepEqual(weekTwo.map((entry) => entry.name), ['Big Win', 'Small Win', 'Eliminated']);
+});


### PR DESCRIPTION
## What changed

- Match all ten 2026 team names and 2025 finish ranks to the supplied league list, with Matt replacing the screenshot’s John Williams entry.
- Rewrite the joke ticker for the corrected team names.
- Add a shared ranking engine used by the public site, admin, and pick-queue Worker.
- Keep Week 1 fixed to the supplied order while Weeks 2–3 derive their order automatically from completed prior-week standings.
- Correct same-week elimination sorting so that week’s margin is evaluated before last year’s finish and earlier cumulative margin cannot override the rule.
- Preserve the existing cumulative-winning-margin rule only among managers still alive.
- Handle later elimination weeks, all-eliminated scenarios, ties, one-loss buybacks, later buyback losses, stale live-result overrides, and zero eligible managers.

## Why

The previous draft sorter compared cumulative margin before same-week margin, which could produce the wrong order for managers eliminated in the same week. Future public-pick orders were also static placeholders instead of being derived from completed standings.

## Validation

- 21 automated ranking, queue, concurrency, deadline, and submission tests pass
- JavaScript syntax checks pass
- Wrangler production bundle dry-run passes
- Cloudflare Worker deployment verified with Nick first and zero submitted picks
- Local public/admin browser checks show all corrected names, updated jokes, published rules, and automatic Week 2 ordering