### PR TITLE
Start ticker without frame scheduling

### DIFF
--- a/index.html
+++ b/index.html
@@ -531,14 +531,11 @@
 
       // Measure after the populated ticker has been laid out, including on the first render.
       React.useLayoutEffect(() => {
-        let secondFrame = null;
-        const firstFrame = requestAnimationFrame(() => {
-          secondFrame = requestAnimationFrame(recomputeTicker);
-        });
-        return () => {
-          cancelAnimationFrame(firstFrame);
-          if (secondFrame !== null) cancelAnimationFrame(secondFrame);
-        };
+        recomputeTicker();
+        // Recheck once after paint/font fallback without relying on requestAnimationFrame,
+        // which browsers may defer for a newly opened background tab.
+        const timer = setTimeout(recomputeTicker, 100);
+        return () => clearTimeout(timer);
       }, [streamJokes, recomputeTicker]);
       useEffect(() => {
         const onResize = () => recomputeTicker();

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Minimal service worker for installability and basic offline support */
-const CACHE_NAME = 'survivor-pool-v7-20260812';
+const CACHE_NAME = 'survivor-pool-v8-20260812';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## What changed

- Start the ticker synchronously in the initial layout effect.
- Recheck after 100 ms without relying on `requestAnimationFrame`.
- Bump the service-worker cache again.

## Why

Public verification showed that a newly opened inactive tab can defer `requestAnimationFrame`, leaving the ticker’s animation name unset. A layout-effect start works immediately and the timer handles any post-paint font/layout adjustment.

## Validation

- Fresh local load reports `marqueeVar`, `running`, and a changing transform over 1.2 seconds.
- Alive cards remain 10 alive and 0 eliminated.
- JavaScript syntax and diff checks pass.