### PR TITLE
Use CSS joke marquee

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,14 +68,15 @@
       animation: trophy 2s infinite;
       display: inline-block;
     }
-    /* Marquee for joke ticker */
-    /* Marquee using CSS variables for precise from/to offsets */
-    @keyframes marqueeVar {
-      0% { transform: translateX(var(--from, 100%)); }
-      100% { transform: translateX(var(--to, -100%)); }
+    /* Two identical streams make a seamless, timing-independent marquee. */
+    @keyframes marqueeLoop {
+      from { transform: translateX(0); }
+      to { transform: translateX(-50%); }
     }
     .ticker-track {
-      animation-timing-function: linear;
+      display: inline-flex;
+      width: max-content;
+      animation: marqueeLoop 120s linear infinite;
       white-space: nowrap;
       will-change: transform;
     }
@@ -475,9 +476,6 @@
       }, [fantasyADP, adpPosition]);
 
       // --- Easter Egg: Live Joke Ticker (continuous stream) ---
-      const tickerWrapRef = useRef(null);
-      const tickerTextRef = useRef(null); // first copy of stream for measurement
-      const tickerTrackRef = useRef(null);
       const jokes = useMemo(() => [
         "Nick (Bake Her Lamb Raw) — Nick named the team like a cooking instruction whispered during a health-code violation. The roster will be served rare, overpriced, and somehow still blamed on the commissioner.",
         "Ryan (RIP Doug Martin) — Ryan built a memorial team for Doug Martin, which is touching until you realize his draft strategy also died around 2017. Respectful service, terrible waiver priority.",
@@ -500,81 +498,6 @@
         }
         setStreamJokes(arr);
       }, [jokes]);
-
-      // Helper: recompute marquee metrics and restart animation with consistent speed
-      const recomputeTicker = React.useCallback(() => {
-        const wrap = tickerWrapRef.current;
-        const text = tickerTextRef.current;
-        const track = tickerTrackRef.current;
-        if (!wrap || !text || !track) return;
-        if (text.childElementCount === 0) return; // wait until jokes are rendered
-        // Ensure measurement spans are laid out
-        const contentW = Math.max(1, text.scrollWidth);
-        // Constant reading speed in px/sec (tuned for readability)
-        const PX_PER_SEC = 20;
-        let seconds = contentW / PX_PER_SEC;
-        // Clamp duration to avoid extremes
-        seconds = Math.max(35, Math.min(120, seconds));
-        // Apply CSS variables and restart the animation cleanly
-        track.style.setProperty('--from', '0px');
-        track.style.setProperty('--to', `-${contentW}px`);
-        track.style.animationName = 'none';
-        // Force reflow to reset animation
-        // eslint-disable-next-line no-unused-expressions
-        track.offsetWidth;
-        track.style.animationTimingFunction = 'linear';
-        track.style.animationDuration = `${seconds}s`;
-        track.style.animationIterationCount = 'infinite';
-        track.style.animationName = 'marqueeVar';
-        track.style.animationPlayState = 'running';
-      }, []);
-
-      // Measure after the populated ticker has been laid out, including on the first render.
-      React.useLayoutEffect(() => {
-        recomputeTicker();
-        // Recheck once after paint/font fallback without relying on requestAnimationFrame,
-        // which browsers may defer for a newly opened background tab.
-        const timer = setTimeout(recomputeTicker, 100);
-        return () => clearTimeout(timer);
-      }, [streamJokes, recomputeTicker]);
-      useEffect(() => {
-        const onResize = () => recomputeTicker();
-        const onVisibility = () => { if (!document.hidden) recomputeTicker(); };
-        const onOrient = () => recomputeTicker();
-        window.addEventListener('resize', onResize);
-        document.addEventListener('visibilitychange', onVisibility);
-        window.addEventListener('orientationchange', onOrient);
-        return () => {
-          window.removeEventListener('resize', onResize);
-          document.removeEventListener('visibilitychange', onVisibility);
-          window.removeEventListener('orientationchange', onOrient);
-        };
-      }, [recomputeTicker]);
-
-      // After web fonts load, re-measure and restart if width changed significantly
-      useEffect(() => {
-        let cancelled = false;
-        const wrap = tickerWrapRef.current;
-        const text = tickerTextRef.current;
-        if (!wrap || !text) return;
-        const initialW = text.scrollWidth || 1;
-        const recompute = () => {
-          if (cancelled) return;
-          const newW = text.scrollWidth || 1;
-          const delta = Math.abs(newW - initialW);
-          if (delta / Math.max(1, initialW) < 0.05) return; // <5% change: ignore
-          recomputeTicker();
-        };
-        // If browser supports font loading API
-        if (document.fonts && document.fonts.ready) {
-          document.fonts.ready.then(recompute);
-        } else {
-          // Fallback: wait a tick and re-measure once
-          const tid = setTimeout(recompute, 600);
-          return () => { cancelled = true; clearTimeout(tid); };
-        }
-        return () => { cancelled = true; };
-      }, [streamJokes, recomputeTicker]);
 
       // --- Helpers: calendar state from schedule dates ---
       const getWeekRange = (week) => {
@@ -1502,7 +1425,6 @@
           <div className="glass rounded-xl p-2 mb-4 flex items-center gap-2 text-sm animate-fade-in" aria-live="polite" aria-label="Live joke ticker">
             <span className="px-2 py-0.5 rounded-full bg-red-500/80 text-black text-xs font-bold">LIVE</span>
             <div 
-              ref={tickerWrapRef} 
               className="relative overflow-hidden w-full cursor-pointer"
               onClick={reshuffleStream}
               onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); reshuffleStream(); } }}
@@ -1511,11 +1433,10 @@
               title="Click to reshuffle jokes"
             >
               <div 
-                ref={tickerTrackRef}
                 className="ticker-track text-amber-200"
               >
                 {/* First copy (measured) */}
-                <span ref={tickerTextRef} className="inline-block">
+                <span className="inline-block">
                   {streamJokes.map((j, idx) => (
                     <span key={`a${idx}`} className="pr-10">{j}</span>
                   ))}

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Minimal service worker for installability and basic offline support */
-const CACHE_NAME = 'survivor-pool-v8-20260812';
+const CACHE_NAME = 'survivor-pool-v9-20260812';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## What changed

- Replace the JavaScript-measured ticker with a pure CSS seamless marquee.
- Size the two-copy track to its content and translate it exactly 50% for a continuous loop.
- Remove 88 lines of timing, visibility, resize, and font-measurement code.
- Bump the service-worker cache.

## Why

The imperative animation could remain unset on the deployed page even though the same code worked locally. A declarative CSS animation has no React effect, frame-scheduling, font-loading, or tab-visibility dependency.

## Validation

- Fresh local load reports `marqueeLoop`, `running`, 120 seconds, and a changing transform.
- The track width equals both identical joke streams, making the 50% loop seamless.
- Stats remain 10 alive and 0 eliminated.
- All 21 tests and syntax checks pass.