### PR TITLE
Harden pick submission and weekly pool progression

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Single-page React app (vanilla React via `<script>` in `index.html`) hosted on G
 - Picks lock at their explicit Eastern Time kickoff.
 - Audio assets lazy-load and a global mute preference persists in `localStorage`.
 - The admin validates data and previews changes before saving to the Gist.
-- The public queue shows only the next eligible manager, validates the active week and deadline, and advances after one accepted pick.
+- The public queue shows only the next eligible manager, validates the active week and deadline, prevents two managers from taking the same team in one week, and advances after one accepted pick.
 
 ## Data and Persistence
 

--- a/admin-logic.js
+++ b/admin-logic.js
@@ -1,0 +1,207 @@
+(function (root, factory) {
+  const ranking = root.SurvivorRanking || (typeof require === 'function' ? require('./ranking.js') : null);
+  const api = factory(ranking);
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  root.SurvivorAdminLogic = api;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function (SurvivorRanking) {
+  'use strict';
+
+  const TOTAL_WEEKS = 3;
+  const FINAL_RESULTS = new Set(['W', 'L', 'T']);
+
+  const normalizeJson = (data) => JSON.stringify(data, null, 2);
+
+  const resultKey = (value) => {
+    const normalized = String(value || '').trim().toUpperCase();
+    return FINAL_RESULTS.has(normalized) ? normalized : null;
+  };
+
+  const findWeekPick = (manager, week) => (Array.isArray(manager && manager.picks) ? manager.picks : [])
+    .find((pick) => Number(pick && pick.week) === Number(week));
+
+  const findFinalOutcome = (events, teamName) => {
+    const wantedTeam = String(teamName || '').trim();
+    if (!wantedTeam) return null;
+
+    for (const event of Array.isArray(events) ? events : []) {
+      const competition = event && event.competitions && event.competitions[0];
+      const competitors = competition && Array.isArray(competition.competitors)
+        ? competition.competitors
+        : [];
+      const selected = competitors.find((competitor) => competitor && competitor.team
+        && competitor.team.displayName === wantedTeam);
+      const opponent = competitors.find((competitor) => competitor !== selected);
+      const state = event && event.status && event.status.type && event.status.type.state;
+      if (!selected || !opponent || state !== 'post') continue;
+
+      const selectedScore = Number(selected.score);
+      const opponentScore = Number(opponent.score);
+      if (!Number.isFinite(selectedScore) || !Number.isFinite(opponentScore)) continue;
+
+      const margin = selectedScore - opponentScore;
+      return {
+        margin,
+        result: margin > 0 ? 'W' : margin < 0 ? 'L' : 'T'
+      };
+    }
+
+    return null;
+  };
+
+  const syncComputedManagers = (managers, activeWeek) => {
+    if (!SurvivorRanking || typeof SurvivorRanking.analyzeManager !== 'function') {
+      throw new Error('Survivor ranking logic is unavailable.');
+    }
+    return (Array.isArray(managers) ? managers : []).map((manager) => {
+      const standing = SurvivorRanking.analyzeManager(manager, {
+        totalWeeks: TOTAL_WEEKS,
+        // Never let a stale or accidentally prefilled future-week result affect
+        // the current elimination state or next-week order.
+        throughWeek: Math.max(1, Math.min(TOTAL_WEEKS, Number(activeWeek || 1))),
+        activeWeek: Number(activeWeek || 1)
+      });
+      return {
+        ...manager,
+        eliminated: standing.isEliminated,
+        marginOfVictory: standing.totalMargin,
+        eliminationWeek: standing.eliminationWeek || null
+      };
+    });
+  };
+
+  const eligibleEnteringWeek = (manager, week) => {
+    if (!SurvivorRanking || typeof SurvivorRanking.analyzeManager !== 'function') return false;
+    const priorWeek = Math.max(0, Number(week) - 1);
+    return !SurvivorRanking.analyzeManager(manager, {
+      totalWeeks: TOTAL_WEEKS,
+      throughWeek: priorWeek,
+      activeWeek: Math.max(1, priorWeek)
+    }).isEliminated;
+  };
+
+  const applyFinalScores = (managers, week, events, timestamp) => {
+    let updatedPicks = 0;
+    const nextManagers = structuredClone(Array.isArray(managers) ? managers : []);
+
+    nextManagers.forEach((manager) => {
+      const pick = findWeekPick(manager, week);
+      if (!pick || !String(pick.team || '').trim()) return;
+
+      const hasValidManualOverride = pick.manualResult === true
+        && resultKey(pick.result) !== null
+        && Number.isFinite(Number(pick.margin));
+      if (hasValidManualOverride) return;
+
+      const outcome = findFinalOutcome(events, pick.team);
+      if (!outcome) return;
+
+      if (resultKey(pick.result) !== outcome.result || Number(pick.margin) !== outcome.margin || pick.manualResult !== false) {
+        updatedPicks += 1;
+      }
+      pick.result = outcome.result;
+      pick.margin = outcome.margin;
+      pick.manualResult = false;
+      pick.lastUpdated = timestamp;
+    });
+
+    return { managers: nextManagers, updatedPicks };
+  };
+
+  const validateFinalizedWeek = (managers, week) => {
+    const errors = [];
+    const weeklyOwners = new Map();
+
+    (Array.isArray(managers) ? managers : []).forEach((manager) => {
+      if (!eligibleEnteringWeek(manager, week)) return;
+      const pick = findWeekPick(manager, week);
+      const team = String(pick && pick.team || '').trim();
+      if (!team) {
+        errors.push(`${manager.name} has no Week ${week} pick.`);
+        return;
+      }
+
+      const teamKey = team.toLowerCase();
+      if (weeklyOwners.has(teamKey)) {
+        errors.push(`${team} is assigned to both ${weeklyOwners.get(teamKey)} and ${manager.name} in Week ${week}.`);
+      } else {
+        weeklyOwners.set(teamKey, manager.name);
+      }
+
+      if (!resultKey(pick.result)) {
+        errors.push(`${manager.name}'s Week ${week} game is not final yet.`);
+      } else if (!Number.isFinite(Number(pick.margin))) {
+        errors.push(`${manager.name}'s Week ${week} margin is missing.`);
+      } else {
+        const result = resultKey(pick.result);
+        const margin = Number(pick.margin);
+        if (result === 'W' && margin <= 0) {
+          errors.push(`${manager.name}'s Week ${week} win must have a positive margin.`);
+        } else if (result === 'L' && margin >= 0) {
+          errors.push(`${manager.name}'s Week ${week} loss must have a negative margin.`);
+        } else if (result === 'T' && margin !== 0) {
+          errors.push(`${manager.name}'s Week ${week} tie must have a zero margin.`);
+        }
+      }
+    });
+
+    return errors;
+  };
+
+  const finalizePoolWeek = (data, events, week, timestamp = new Date().toISOString()) => {
+    const activeWeek = Number(week);
+    if (!Number.isInteger(activeWeek) || activeWeek < 1 || activeWeek > TOTAL_WEEKS) {
+      throw new Error('Active week must be between 1 and 3.');
+    }
+
+    const scored = applyFinalScores(data && data.managers, activeWeek, events, timestamp);
+    const errors = validateFinalizedWeek(scored.managers, activeWeek);
+    const computedManagers = syncComputedManagers(scored.managers, activeWeek);
+    const canAdvance = errors.length === 0;
+    const survivorCount = computedManagers.filter((manager) => manager.eliminated !== true).length;
+    const poolComplete = canAdvance && (activeWeek === TOTAL_WEEKS || survivorCount === 0);
+    const nextWeek = canAdvance && !poolComplete ? activeWeek + 1 : activeWeek;
+    const currentQueue = data && data.pickQueue ? data.pickQueue : {};
+    const nextQueue = canAdvance
+      ? {
+          ...currentQueue,
+          enabled: false,
+          activeWeek: nextWeek,
+          completed: poolComplete,
+          finalizedWeeks: {
+            ...(currentQueue.finalizedWeeks || {}),
+            [String(activeWeek)]: {
+              finalizedAt: timestamp,
+              source: 'espn',
+              updatedPicks: scored.updatedPicks
+            }
+          }
+        }
+      : currentQueue;
+
+    return {
+      data: {
+        ...(data || {}),
+        managers: computedManagers,
+        pickQueue: nextQueue,
+        lastUpdated: timestamp
+      },
+      errors,
+      updatedPicks: scored.updatedPicks,
+      finalized: canAdvance,
+      advanced: canAdvance && !poolComplete,
+      nextWeek,
+      poolComplete,
+      survivorCount
+    };
+  };
+
+  return Object.freeze({
+    applyFinalScores,
+    eligibleEnteringWeek,
+    finalizePoolWeek,
+    findFinalOutcome,
+    normalizeJson,
+    syncComputedManagers,
+    validateFinalizedWeek
+  });
+}));

--- a/admin.html
+++ b/admin.html
@@ -250,6 +250,7 @@
         const poolManagers = Array.isArray(data && data.managers) ? data.managers : [];
         const rankOwners = new Map();
         const nameOwners = new Map();
+        const weeklyTeamOwners = new Map();
 
         poolManagers.forEach((manager, index) => {
           const name = String(manager && manager.name || '').trim();
@@ -276,10 +277,22 @@
           (Array.isArray(manager && manager.picks) ? manager.picks : []).forEach((pick, pickIndex) => {
             const team = String(pick && pick.team || '').trim();
             if (!team) return;
-            if (usedTeams.has(team)) {
+            const teamKey = team.toLowerCase();
+            if (usedTeams.has(teamKey)) {
               errors.push({ instancePath: `/managers/${index}/picks/${pickIndex}/team`, message: `reuses ${team} in another week` });
             }
-            usedTeams.add(team);
+            usedTeams.add(teamKey);
+
+            const week = Number(pick && pick.week) || pickIndex + 1;
+            const weeklyKey = `${week}:${teamKey}`;
+            if (weeklyTeamOwners.has(weeklyKey)) {
+              errors.push({
+                instancePath: `/managers/${index}/picks/${pickIndex}/team`,
+                message: `duplicates ${team} in Week ${week}; already picked by ${weeklyTeamOwners.get(weeklyKey)}`
+              });
+            } else {
+              weeklyTeamOwners.set(weeklyKey, name || `manager ${index + 1}`);
+            }
           });
         });
 
@@ -490,10 +503,27 @@
         };
       });
 
+      const getTeamConflict = (managerIndex, weekIndex, team) => {
+        if (!team) return null;
+        const manager = managers[managerIndex];
+        const week = Number(manager && manager.picks && manager.picks[weekIndex] && manager.picks[weekIndex].week) || weekIndex + 1;
+        const reusedByManager = (manager && Array.isArray(manager.picks) ? manager.picks : [])
+          .some((pick, index) => index !== weekIndex && pick.team === team);
+        if (reusedByManager) return 'another-week';
+        const weeklyOwner = managers.find((candidate, index) => index !== managerIndex
+          && (Array.isArray(candidate && candidate.picks) ? candidate.picks : [])
+            .some((pick) => Number(pick && pick.week) === week && pick.team === team));
+        return weeklyOwner ? { type: 'same-week', manager: weeklyOwner.name, week } : null;
+      };
+
       const handlePickChange = (managerIndex, weekIndex, value) => {
-        // Prevent duplicate team picks for the same manager
-        if (value && managers[managerIndex].picks.some((p, idx) => idx !== weekIndex && p.team === value)) {
+        const conflict = getTeamConflict(managerIndex, weekIndex, value);
+        if (conflict === 'another-week') {
           showNotification('This team is already used in another week for this manager', 'error');
+          return;
+        }
+        if (conflict && conflict.type === 'same-week') {
+          showNotification(`${value} is already picked by ${conflict.manager} for Week ${conflict.week}`, 'error');
           return;
         }
         const updatedManagers = structuredClone(managers);
@@ -1116,10 +1146,10 @@
                               <option
                                 key={team}
                                 value={team}
-                                disabled={manager.picks.some((p, idx) => idx !== weekIndex && p.team === team)}
+                                disabled={Boolean(getTeamConflict(managerIndex, weekIndex, team))}
                               >
                                 {team}
-                                {manager.picks.some((p, idx) => idx !== weekIndex && p.team === team) ? ' (used)' : ''}
+                                {getTeamConflict(managerIndex, weekIndex, team) ? ' (used)' : ''}
                               </option>
                             ))}
                           </select>

--- a/admin.html
+++ b/admin.html
@@ -10,6 +10,7 @@
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" integrity="sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1" crossorigin="anonymous"></script>
   <script src="ranking.js"></script>
+  <script src="admin-logic.js"></script>
   <!-- Babel Standalone enables JSX in the browser -->
   <script src="https://unpkg.com/@babel/standalone@7.28.5/babel.min.js" integrity="sha384-mP9sW+eK08VvAmlxEkn9Kn6egvKFtnFEfW7/u9feUWAIoTvnYAzT4NwsskP+uWUd" crossorigin="anonymous"></script>
   <!-- Font Awesome for icons -->
@@ -125,6 +126,7 @@
       const [gistId, setGistId] = useState((localStorage.getItem('gistId') || '').trim());
       // The token is intentionally session-only and is cleared after each save.
       const [gistToken, setGistToken] = useState('');
+      const [pickQueueApiBase, setPickQueueApiBase] = useState('');
       const [dataSource, setDataSource] = useState('loading');
       const [isSaving, setIsSaving] = useState(false);
       const [dirty, setDirty] = useState(false);
@@ -133,6 +135,10 @@
       const [showSavePreview, setShowSavePreview] = useState(false);
       const [diffLines, setDiffLines] = useState([]);
       const [validationErrors, setValidationErrors] = useState([]);
+      const [saveConflict, setSaveConflict] = useState('');
+      const [pendingSaveData, setPendingSaveData] = useState(null);
+      const [isFinalizingWeek, setIsFinalizingWeek] = useState(false);
+      const [weekAdvanceErrors, setWeekAdvanceErrors] = useState([]);
       // File input ref for importing JSON
       const fileInputRef = useRef(null);
       
@@ -157,22 +163,24 @@
         return () => window.removeEventListener('beforeunload', warnOnUnsavedChanges);
       }, [dirty]);
 
-      // If no gistId (or whitespace) in localStorage/state, try to default from config.json
+      // Load non-secret persistence endpoints from the repository config.
       useEffect(() => {
-        if (!gistId || !gistId.trim()) {
-          fetch(`config.json?t=${Date.now()}`)
-            .then(res => res.ok ? res.json() : null)
-            .then(cfg => {
-              if (cfg && cfg.gistId) {
+        fetch(`config.json?t=${Date.now()}`)
+          .then(res => res.ok ? res.json() : null)
+          .then(cfg => {
+            if (cfg) {
+              const apiBase = cfg.features && cfg.features.pickSubmission && cfg.features.pickSubmission.apiBase;
+              if (apiBase) setPickQueueApiBase(String(apiBase).replace(/\/$/, ''));
+              if ((!gistId || !gistId.trim()) && cfg.gistId) {
                 const id = String(cfg.gistId).trim();
                 if (id) {
                   setGistId(id);
                   localStorage.setItem('gistId', id);
                 }
               }
-            })
-            .catch(() => {});
-        }
+            }
+          })
+          .catch(() => {});
       }, [gistId]);
 
       // Lightweight JSON Schema for admin validation (kept permissive to avoid blocking legitimate data)
@@ -230,7 +238,7 @@
                     properties: {
                       week: { type: 'integer' },
                       team: { type: 'string' },
-                      result: { type: ['string', 'null'], enum: ['W', 'L', null] },
+                      result: { type: ['string', 'null'], enum: ['W', 'L', 'T', null] },
                       margin: { type: ['number', 'integer'] },
                       manualResult: { type: 'boolean' },
                       lastUpdated: { type: 'string' }
@@ -368,6 +376,8 @@
         }
         // Validate and prepare diff preview before confirming save
         const dataToSave = getDataToSave();
+        setPendingSaveData(dataToSave);
+        setSaveConflict('');
         const validation = validateAgainstSchema(dataToSave);
         if (!validation.valid) {
           setValidationErrors((validation.errors || []).map(err => `${err.instancePath || 'data'} ${err.message}`));
@@ -431,6 +441,32 @@
         setNotification({ message, type });
         setTimeout(() => setNotification(null), 3000);
       };
+
+      const fetchGistSnapshot = async (id, token = '') => {
+        const headers = { 'Accept': 'application/vnd.github+json' };
+        if (token) headers.Authorization = `Bearer ${token}`;
+        const metaRes = await fetch(`https://api.github.com/gists/${id}?t=${Date.now()}`, { headers });
+        if (!metaRes.ok) throw new Error(`Gist metadata fetch failed: ${metaRes.status}`);
+        const meta = await metaRes.json();
+        const dataFile = meta.files && (meta.files['data.json'] || meta.files['data.JSON']);
+        if (!dataFile) throw new Error('data.json not found in Gist');
+
+        let data;
+        if (typeof dataFile.content === 'string' && dataFile.truncated !== true) {
+          data = JSON.parse(dataFile.content);
+        } else {
+          if (!dataFile.raw_url) throw new Error('data.json has no readable URL');
+          const rawRes = await fetch(`${dataFile.raw_url}?t=${Date.now()}`, { headers });
+          if (!rawRes.ok) throw new Error(`Gist raw fetch failed: ${rawRes.status}`);
+          data = await rawRes.json();
+        }
+
+        return {
+          data,
+          normalized: SurvivorAdminLogic.normalizeJson(data),
+          revision: (meta.history && meta.history[0] && meta.history[0].version) || meta.updated_at || ''
+        };
+      };
       
       const loadData = async () => {
         let ignoredPriorSeasonGist = false;
@@ -438,14 +474,8 @@
         // Try Gist first if configured; otherwise fall back to local data.json
         if (gistId) {
           try {
-            const metaRes = await fetch(`https://api.github.com/gists/${gistId}`);
-            if (!metaRes.ok) throw new Error(`Gist metadata fetch failed: ${metaRes.status}`);
-            const meta = await metaRes.json();
-            const dataFile = meta.files && (meta.files['data.json'] || meta.files['data.JSON']);
-            if (!dataFile || !dataFile.raw_url) throw new Error('data.json not found in Gist');
-            const res = await fetch(`${dataFile.raw_url}?t=${Date.now()}`);
-            if (!res.ok) throw new Error(`Gist raw fetch failed: ${res.status}`);
-            const data = await res.json();
+            const snapshot = await fetchGistSnapshot(gistId);
+            const data = snapshot.data;
             if (!isCurrentSeasonData(data)) {
               ignoredPriorSeasonGist = true;
               const mismatchError = new Error(`Ignoring non-${SEASON_YEAR} Gist data`);
@@ -454,10 +484,13 @@
             }
             setManagers(data.managers || []);
             setCompleteData(data);
-            setJsonData(JSON.stringify(data, null, 2));
-            setBaselineJson(JSON.stringify(data, null, 2));
+            setJsonData(snapshot.normalized);
+            setBaselineJson(snapshot.normalized);
             setDataSource('gist');
             setDirty(false);
+            setSaveConflict('');
+            setPendingSaveData(null);
+            setWeekAdvanceErrors([]);
             return;
           } catch (err) {
             if (err && err.code === 'season_mismatch') {
@@ -479,6 +512,9 @@
           setBaselineJson(JSON.stringify(data, null, 2));
           setDataSource('repository');
           setDirty(false);
+          setSaveConflict('');
+          setPendingSaveData(null);
+          setWeekAdvanceErrors([]);
           if (ignoredPriorSeasonGist) {
             showNotification(`Loaded ${SEASON_YEAR} starter data; last season's Gist was left untouched`, 'success');
           }
@@ -489,19 +525,10 @@
         }
       };
       
-      const syncComputedManagerState = (poolManagers) => poolManagers.map((manager) => {
-        const standing = SurvivorRanking.analyzeManager(manager, {
-          totalWeeks: 3,
-          throughWeek: 3,
-          activeWeek: Number((completeData.pickQueue && completeData.pickQueue.activeWeek) || 1)
-        });
-        return {
-          ...manager,
-          eliminated: standing.isEliminated,
-          marginOfVictory: standing.totalMargin,
-          ...(standing.eliminationWeek ? { eliminationWeek: standing.eliminationWeek } : { eliminationWeek: null })
-        };
-      });
+      const syncComputedManagerState = (poolManagers) => SurvivorAdminLogic.syncComputedManagers(
+        poolManagers,
+        Number((completeData.pickQueue && completeData.pickQueue.activeWeek) || 1)
+      );
 
       const getTeamConflict = (managerIndex, weekIndex, team) => {
         if (!team) return null;
@@ -517,6 +544,9 @@
       };
 
       const handlePickChange = (managerIndex, weekIndex, value) => {
+        const currentPick = managers[managerIndex] && managers[managerIndex].picks
+          && managers[managerIndex].picks[weekIndex];
+        if (String(currentPick && currentPick.team || '') === value) return;
         const conflict = getTeamConflict(managerIndex, weekIndex, value);
         if (conflict === 'another-week') {
           showNotification('This team is already used in another week for this manager', 'error');
@@ -527,14 +557,27 @@
           return;
         }
         const updatedManagers = structuredClone(managers);
+        const {
+          result: _oldResult,
+          margin: _oldMargin,
+          submittedAt: _oldSubmittedAt,
+          submittedBy: _oldSubmittedBy,
+          manualResult: _oldManualResult,
+          lastUpdated: _oldLastUpdated,
+          ...pickIdentity
+        } = updatedManagers[managerIndex].picks[weekIndex];
         updatedManagers[managerIndex].picks[weekIndex] = {
-          ...updatedManagers[managerIndex].picks[weekIndex],
+          ...pickIdentity,
           team: value,
-          manualResult: true, // Mark as manual when team is changed
+          result: null,
+          margin: 0,
+          manualTeam: true,
+          manualResult: false,
           lastUpdated: new Date().toISOString()
         };
-        setManagers(updatedManagers);
-        updateJsonData(updatedManagers);
+        const computedManagers = syncComputedManagerState(updatedManagers);
+        setManagers(computedManagers);
+        updateJsonData(computedManagers);
       };
       
       const handleResultChange = (managerIndex, weekIndex, value) => {
@@ -542,7 +585,7 @@
         updatedManagers[managerIndex].picks[weekIndex] = {
           ...updatedManagers[managerIndex].picks[weekIndex],
           result: value,
-          manualResult: true, // Mark as manual result
+          manualResult: value !== null,
           lastUpdated: new Date().toISOString()
         };
         
@@ -630,6 +673,70 @@
         setDirty(true);
       };
 
+      const handleActiveWeekSelection = (requestedWeek) => {
+        const currentWeek = Number((completeData.pickQueue && completeData.pickQueue.activeWeek) || 1);
+        if (Number(requestedWeek) === currentWeek) return;
+        setWeekAdvanceErrors([
+          Number(requestedWeek) > currentWeek
+            ? `Week ${currentWeek} must be finalized before Week ${requestedWeek} can open.`
+            : 'Moving the queue backward is blocked because it can reopen completed picks. Use a reviewed JSON import for emergency recovery.'
+        ]);
+        showNotification('Use the guarded week-finalization control', 'error');
+      };
+
+      const finalizeActiveWeek = async () => {
+        const activeWeek = Number((completeData.pickQueue && completeData.pickQueue.activeWeek) || 1);
+        if (completeData.pickQueue && completeData.pickQueue.completed === true) {
+          showNotification('The pool is already finalized', 'error');
+          return;
+        }
+        const espnWeek = Math.min(4, Math.max(2, activeWeek + 1));
+        setIsFinalizingWeek(true);
+        setWeekAdvanceErrors([]);
+        try {
+          const scoreboardUrl = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard?dates=${SEASON_YEAR}&seasontype=1&week=${espnWeek}&limit=100`;
+          const response = await fetch(scoreboardUrl);
+          if (!response.ok) throw new Error(`ESPN scoreboard fetch failed: ${response.status}`);
+          const scoreboard = await response.json();
+          const timestamp = new Date().toISOString();
+          const result = SurvivorAdminLogic.finalizePoolWeek(
+            { ...completeData, season: SEASON_YEAR, managers },
+            scoreboard.events || [],
+            activeWeek,
+            timestamp
+          );
+
+          if (result.finalized || result.updatedPicks > 0) {
+            setManagers(result.data.managers);
+            setCompleteData(result.data);
+            setJsonData(JSON.stringify(result.data, null, 2));
+            setDirty(true);
+          }
+
+          if (!result.finalized) {
+            setWeekAdvanceErrors(result.errors);
+            const stagedSuffix = result.updatedPicks > 0 ? ` ${result.updatedPicks} final result${result.updatedPicks === 1 ? '' : 's'} were staged.` : '';
+            showNotification(`Week ${activeWeek} is not ready to finalize.${stagedSuffix}`, 'error');
+            return;
+          }
+
+          setWeekAdvanceErrors([]);
+          if (result.advanced) {
+            showNotification(`Week ${activeWeek} finalized. Week ${result.nextWeek} is staged with the queue closed.`, 'success');
+          } else if (result.survivorCount === 0) {
+            showNotification(`Week ${activeWeek} finalized. Everyone was eliminated, so the pool is complete.`, 'success');
+          } else {
+            showNotification('Week 3 finalized and the public queue is closed.', 'success');
+          }
+        } catch (err) {
+          console.error('Week finalization failed:', err);
+          setWeekAdvanceErrors(['Could not retrieve the official preseason scoreboard. Nothing was advanced; try again shortly.']);
+          showNotification('Week finalization failed; the active week was not changed', 'error');
+        } finally {
+          setIsFinalizingWeek(false);
+        }
+      };
+
       // Copy current JSON to clipboard
       const copyJson = async () => {
         try {
@@ -691,39 +798,53 @@
           console.warn('Save to Gist blocked: missing credentials', { hasId: !!id, hasToken: !!token });
           setShowSettings(true);
           showNotification('Configure Gist ID and Token in Settings first', 'error');
-          return;
+          return false;
         }
         try {
           setIsSaving(true);
+          setSaveConflict('');
           console.log('Saving to Gist...', { id: id.slice(0,4) + '...' + id.slice(-4) });
-          
-          // Ensure we save the complete data structure including gameResults
-          const dataToSave = getDataToSave();
-          
-          const payload = {
-            files: {
-              'data.json': { content: JSON.stringify(dataToSave, null, 2) }
-            }
-          };
-          const res = await fetch(`https://api.github.com/gists/${id}`, {
-            method: 'PATCH',
+
+          // Save the exact document shown in the confirmation preview.
+          const dataToSave = pendingSaveData || getDataToSave();
+          if (!pickQueueApiBase) throw new Error('Pick queue service URL is unavailable');
+          const res = await fetch(`${pickQueueApiBase}/admin-save`, {
+            method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              'Authorization': `token ${token}`
+              'Authorization': `Bearer ${token}`
             },
-            body: JSON.stringify(payload)
+            body: JSON.stringify({
+              gistId: id,
+              baseline: baselineJson ? JSON.parse(baselineJson) : null,
+              data: dataToSave
+            })
           });
           if (!res.ok) {
-            const t = await res.text();
-            throw new Error(`Gist save failed: ${res.status} ${t}`);
+            const failure = await res.json().catch(() => ({}));
+            if (res.status === 409 && failure.error === 'live_data_changed') {
+              const conflictMessage = 'The live Gist changed after this admin page loaded, likely because a pick was submitted. Your changes were not saved. Download a backup if needed, then reload and reapply them to the latest data.';
+              setSaveConflict(conflictMessage);
+              showNotification('Save blocked: newer live data was found', 'error');
+              return false;
+            }
+            throw new Error(failure.message || `Gist save failed: ${res.status}`);
           }
+          const savedJson = JSON.stringify(dataToSave, null, 2);
+          setCompleteData(dataToSave);
+          setJsonData(savedJson);
           setDirty(false);
-          setBaselineJson(JSON.stringify(dataToSave, null, 2));
+          setBaselineJson(savedJson);
+          setDataSource('gist');
+          setPendingSaveData(null);
+          setSaveConflict('');
           setGistToken('');
           showNotification('Saved to Gist successfully', 'success');
+          return true;
         } catch (err) {
           console.error(err);
-          showNotification('Failed to save to Gist. Check Settings.', 'error');
+          showNotification('Failed to verify or save the Gist. No live data was overwritten.', 'error');
+          return false;
         } finally {
           setIsSaving(false);
         }
@@ -760,11 +881,18 @@
       
       const resetPick = (managerIndex, weekIndex) => {
         const updatedManagers = structuredClone(managers);
+        const {
+          submittedAt: _oldSubmittedAt,
+          submittedBy: _oldSubmittedBy,
+          lastUpdated: _oldLastUpdated,
+          ...pickIdentity
+        } = updatedManagers[managerIndex].picks[weekIndex];
         updatedManagers[managerIndex].picks[weekIndex] = {
-          ...updatedManagers[managerIndex].picks[weekIndex],
+          ...pickIdentity,
           team: '',
           result: null,
           margin: 0,
+          manualTeam: false,
           manualResult: false,
           lastUpdated: new Date().toISOString()
         };
@@ -1037,7 +1165,7 @@
                   <label className="block text-sm mb-1">Active Week</label>
                   <select
                     value={pickQueueConfig.activeWeek}
-                    onChange={(event) => updatePickQueue({ activeWeek: Number(event.target.value) })}
+                    onChange={(event) => handleActiveWeekSelection(Number(event.target.value))}
                     className="w-full p-2 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
                   >
                     {[1, 2, 3].map((week) => <option key={week} value={week}>Week {week}</option>)}
@@ -1049,6 +1177,38 @@
                     {activeQueueDeadline ? new Date(activeQueueDeadline).toLocaleString([], { timeZone: 'America/New_York', dateStyle: 'medium', timeStyle: 'short' }) + ' ET' : 'No deadline configured'}
                   </div>
                 </div>
+              </div>
+              <div className="mt-5 rounded-xl border border-amber-300/30 bg-amber-950/20 p-4">
+                <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+                  <div>
+                    <div className="font-semibold">Guarded week finalization</div>
+                    <p className="text-sm text-purple-100 mt-1">
+                      Imports official ESPN finals for Week {pickQueueConfig.activeWeek}, validates every eligible pick, recomputes eliminations and rankings, then stages the next week with the queue closed.
+                    </p>
+                  </div>
+                  <button
+                    onClick={finalizeActiveWeek}
+                    disabled={isFinalizingWeek || pickQueueConfig.completed === true}
+                    className={`shrink-0 px-4 py-2 rounded-lg font-semibold transition-colors ${isFinalizingWeek || pickQueueConfig.completed === true ? 'bg-amber-900 cursor-not-allowed opacity-70' : 'bg-amber-600 hover:bg-amber-700'}`}
+                  >
+                    <i className={`fas ${isFinalizingWeek ? 'fa-spinner fa-spin' : 'fa-flag-checkered'} mr-2`}></i>
+                    {pickQueueConfig.completed === true
+                      ? 'Pool finalized'
+                      : isFinalizingWeek
+                      ? 'Checking official finalsâ€¦'
+                      : pickQueueConfig.activeWeek < 3
+                        ? `Finalize Week ${pickQueueConfig.activeWeek} & Prepare Week ${pickQueueConfig.activeWeek + 1}`
+                        : 'Finalize Week 3 & Close Queue'}
+                  </button>
+                </div>
+                {weekAdvanceErrors.length > 0 && (
+                  <div className="mt-3 rounded-lg bg-red-600/25 border border-red-400/40 p-3">
+                    <div className="font-semibold text-red-100">Week was not advanced:</div>
+                    <ul className="list-disc pl-5 mt-1 text-sm text-red-100 max-h-40 overflow-auto">
+                      {weekAdvanceErrors.map((message, index) => <li key={index}>{message}</li>)}
+                    </ul>
+                  </div>
+                )}
               </div>
               <div className="mt-5">
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-2">
@@ -1165,6 +1325,7 @@
                             <option value="">Not decided</option>
                             <option value="W">Win</option>
                             <option value="L">Loss</option>
+                            <option value="T">Tie</option>
                           </select>
                         </div>
                         
@@ -1321,6 +1482,12 @@
                     </ul>
                   </div>
                 )}
+                {saveConflict && (
+                  <div className="mb-4 p-3 rounded bg-amber-600/30 border border-amber-300/50 text-amber-100">
+                    <div className="font-semibold mb-1">Newer live data detected</div>
+                    <p className="text-sm">{saveConflict}</p>
+                  </div>
+                )}
                 <div className="mb-4 text-sm text-purple-200">Only changed lines are highlighted.</div>
                 <div className="bg-black/40 rounded p-3 max-h-[50vh] overflow-auto text-sm font-mono whitespace-pre-wrap">
                   {diffLines.map((part, idx) => (
@@ -1339,8 +1506,8 @@
                   <button
                     onClick={async () => {
                       if (validationErrors.length === 0) {
-                        await performSaveToGist();
-                        setShowSavePreview(false);
+                        const saved = await performSaveToGist();
+                        if (saved) setShowSavePreview(false);
                       }
                     }}
                     disabled={validationErrors.length > 0 || isSaving}

--- a/index.html
+++ b/index.html
@@ -650,7 +650,7 @@
         if (queue.lastUpdated) setLastUpdated(queue.lastUpdated);
       };
 
-      const fetchPickQueue = async () => {
+      const fetchPickQueue = async ({ preserveError = false } = {}) => {
         const base = String(pickConfig.apiBase || '').replace(/\/$/, '');
         if (!pickConfig.enabled || !base) return;
         setPickQueueLoading(true);
@@ -662,9 +662,9 @@
           }
           setPickQueue(payload.queue);
           mergeQueuePicks(payload.queue);
-          setPickError('');
+          if (!preserveError) setPickError('');
         } catch (error) {
-          setPickError(error.message || 'Pick queue is temporarily unavailable.');
+          if (!preserveError) setPickError(error.message || 'Pick queue is temporarily unavailable.');
         } finally {
           setPickQueueLoading(false);
         }
@@ -690,10 +690,13 @@
         setPickSubmitting(true);
         setPickError('');
         setPickSuccess('');
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 15000);
         try {
           const response = await fetch(`${base}/pick-queue`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
+            signal: controller.signal,
             body: JSON.stringify({
               manager: current.name,
               week: pickQueue.activeWeek,
@@ -711,9 +714,15 @@
           setShowPickConfirm(false);
           await loadData();
         } catch (error) {
-          setPickError(error.message || 'The pick was not accepted.');
-          await fetchPickQueue();
+          const message = error && error.name === 'AbortError'
+            ? 'The pick service took too long to respond. Your pick was not confirmed; try again.'
+            : (error instanceof TypeError
+              ? 'Could not reach the pick service. Check your connection and try again.'
+              : (error.message || 'The pick was not accepted.'));
+          setPickError(message);
+          fetchPickQueue({ preserveError: true });
         } finally {
+          clearTimeout(timeout);
           setPickSubmitting(false);
         }
       };
@@ -1580,6 +1589,11 @@
                   <div className="text-xl font-bold text-cyan-200">{pickTeam}</div>
                 </div>
                 <p className="text-sm text-purple-200 mt-4">There is no self-service undo. If this is wrong, the commissioner can correct it in the admin page.</p>
+                {pickError && (
+                  <div className="mt-4 rounded-xl border border-red-400/50 bg-red-500/25 p-3 text-sm text-red-100" role="alert">
+                    <i className="fas fa-circle-exclamation mr-2"></i>{pickError}
+                  </div>
+                )}
                 <div className="flex justify-end gap-3 mt-6">
                   <button
                     onClick={() => setShowPickConfirm(false)}

--- a/index.html
+++ b/index.html
@@ -763,7 +763,7 @@
               
               // Calculate margins and results for managers' picks
               if (data.events && data.events.length > 0) {
-                calculateAndUpdateFromScores(data.events);
+                calculateAndUpdateFromScores(data.events, activeWeek);
               }
             }
           } catch (err) {
@@ -773,7 +773,7 @@
         }
         
         // Calculate margins and results based on game scores
-        const calculateAndUpdateFromScores = (games) => {
+        const calculateAndUpdateFromScores = (games, poolWeek) => {
           const updatedManagers = managers.map(manager => {
             let newMarginOfVictory = 0;
             let hasUpdatedPick = false;
@@ -781,6 +781,9 @@
             
             // Check each week's pick
             manager.picks.forEach((pick, weekIndex) => {
+              // The fetched scoreboard contains exactly one ESPN preseason week.
+              // Never apply those games to stored picks from another pool week.
+              if (Number(pick && pick.week) !== Number(poolWeek)) return;
               if (pick.team) {
                 // Find the game involving this team
                 const game = games.find(g => {
@@ -813,7 +816,7 @@
                     let result = null;
                     if (margin > 0) result = 'W';
                     else if (margin < 0) result = 'L';
-                    else result = null; // tie -> no W/L
+                    else result = 'T';
                     
                     // Only auto-update if the game is completed and this pick is not a manual override
                     if (status === 'post' && !pick.manualResult) {
@@ -823,7 +826,7 @@
                         manualResult: false, // Mark as automatic result
                         lastUpdated: new Date().toISOString()
                       };
-                      if (result !== null) nextPick.result = result; else delete nextPick.result;
+                      nextPick.result = result;
                       if (pick.result !== result || pick.margin !== margin) {
                         newPicks[weekIndex] = nextPick;
                         hasUpdatedPick = true;
@@ -1767,20 +1770,20 @@
                           key={idx}
                           className={(function(){
                             const outcome = pick.team ? getTeamOutcomeForWeek(pick.team, pick.week) : null;
-                            const liveResult = outcome && outcome.state === 'post' ? (outcome.isTie ? null : (outcome.isWinner ? 'W' : 'L')) : null;
+                            const liveResult = outcome && outcome.state === 'post' ? (outcome.isTie ? 'T' : (outcome.isWinner ? 'W' : 'L')) : null;
                             const effective = pick.result || liveResult;
                             const base = 'px-2 sm:px-3 py-1 rounded-full text-[11px] sm:text-xs font-medium flex items-center gap-1 whitespace-nowrap ';
                             if (effective === 'W') return base + 'bg-green-500/80';
                             if (effective === 'L') return base + 'bg-red-500/80';
+                            if (effective === 'T') return base + 'bg-amber-500/80';
                             return base + 'bg-gray-700/60';
                           })()}
                           title={(function(){
                             const outcome = pick.team ? getTeamOutcomeForWeek(pick.team, pick.week) : null;
-                            const liveResult = outcome && outcome.state === 'post' ? (outcome.isTie ? null : (outcome.isWinner ? 'W' : 'L')) : null;
+                            const liveResult = outcome && outcome.state === 'post' ? (outcome.isTie ? 'T' : (outcome.isWinner ? 'W' : 'L')) : null;
                             const effective = pick.result || liveResult;
                             let resText = 'Pending';
-                            if (effective) resText = (effective === 'W' ? 'Win' : 'Loss');
-                            else if (outcome && outcome.state === 'post' && outcome.isTie) resText = 'Tie';
+                            if (effective) resText = effective === 'W' ? 'Win' : effective === 'L' ? 'Loss' : 'Tie';
                             const liveSuffix = (!pick.result && liveResult) ? ' (Live)' : '';
                             const manualSuffix = pick.manualResult ? ' (Manual override)' : '';
                             // Append stored note if available
@@ -1800,12 +1803,12 @@
                           })()}
                           {(function(){
                             const outcome = pick.team ? getTeamOutcomeForWeek(pick.team, pick.week) : null;
-                            const liveResult = outcome && outcome.state === 'post' ? (outcome.isTie ? null : (outcome.isWinner ? 'W' : 'L')) : null;
+                            const liveResult = outcome && outcome.state === 'post' ? (outcome.isTie ? 'T' : (outcome.isWinner ? 'W' : 'L')) : null;
                             const effective = pick.result || liveResult;
                             if (!effective) return null;
                             return (
                               <span className="font-bold">
-                                {effective === 'W' ? '✓' : '✗'}
+                                {effective === 'W' ? '✓' : effective === 'L' ? '✗' : '–'}
                               </span>
                             );
                           })()}
@@ -2005,7 +2008,7 @@
                         // Check if any manager has a completed result for either team in this week
                         const completedPicks = managersWithPick.filter(mgr => {
                           const pick = mgr.picks.find(p => p.week === week.week);
-                          return pick && (pick.result === 'W' || pick.result === 'L') && pick.margin !== undefined;
+                          return pick && (pick.result === 'W' || pick.result === 'L' || pick.result === 'T') && pick.margin !== undefined;
                         });
                         
                         if (completedPicks.length > 0) {
@@ -2048,9 +2051,9 @@
                                   
                                   // Check live outcome first, then fallback to stored result
                                   if (outcome && outcome.state === 'post') {
-                                    cls = outcome.isWinner ? 'bg-green-500/60' : 'bg-red-500/60';
-                                  } else if (pick && (pick.result === 'W' || pick.result === 'L')) {
-                                    cls = pick.result === 'W' ? 'bg-green-500/60' : 'bg-red-500/60';
+                                    cls = outcome.isTie ? 'bg-amber-500/60' : outcome.isWinner ? 'bg-green-500/60' : 'bg-red-500/60';
+                                  } else if (pick && (pick.result === 'W' || pick.result === 'L' || pick.result === 'T')) {
+                                    cls = pick.result === 'W' ? 'bg-green-500/60' : pick.result === 'L' ? 'bg-red-500/60' : 'bg-amber-500/60';
                                   }
                                   
                                   return (
@@ -2122,7 +2125,7 @@
                             // Check if any manager has a completed result for either team in this week
                             const completedPicks = managersWithPick.filter(mgr => {
                               const pick = mgr.picks.find(p => p.week === week.week);
-                              return pick && (pick.result === 'W' || pick.result === 'L') && pick.margin !== undefined;
+                              return pick && (pick.result === 'W' || pick.result === 'L' || pick.result === 'T') && pick.margin !== undefined;
                             });
                             
                             if (completedPicks.length > 0) {
@@ -2161,9 +2164,9 @@
                                     
                                     // Check live outcome first, then fallback to stored result
                                     if (outcome && outcome.state === 'post') {
-                                      cls = outcome.isWinner ? 'bg-green-500/60' : 'bg-red-500/60';
-                                    } else if (pick && (pick.result === 'W' || pick.result === 'L')) {
-                                      cls = pick.result === 'W' ? 'bg-green-500/60' : 'bg-red-500/60';
+                                      cls = outcome.isTie ? 'bg-amber-500/60' : outcome.isWinner ? 'bg-green-500/60' : 'bg-red-500/60';
+                                    } else if (pick && (pick.result === 'W' || pick.result === 'L' || pick.result === 'T')) {
+                                      cls = pick.result === 'W' ? 'bg-green-500/60' : pick.result === 'L' ? 'bg-red-500/60' : 'bg-amber-500/60';
                                     }
                                     
                                     return (

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,0 +1,1585 @@
+{
+  "name": "howboutit-pick-queue",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "howboutit-pick-queue",
+      "devDependencies": {
+        "wrangler": "4.122.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz",
+      "integrity": "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz",
+      "integrity": "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz",
+      "integrity": "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260811.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260811.0-alpha.tgz",
+      "integrity": "sha512-sypXsD5fjY88fZNedPqnwrwR1dwfnfbfW7MfvMyIfPJdtRiCCOpUnjWGeFVYYZ+0fQVICye6Juu+vZgzTEx8XA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260811.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260811.1.tgz",
+      "integrity": "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260811.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260811.1",
+        "@cloudflare/workerd-linux-64": "1.20260811.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260811.1",
+        "@cloudflare/workerd-windows-64": "1.20260811.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.122.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.122.0.tgz",
+      "integrity": "sha512-qkskzgQ76Y1qvVe5JARgvc3RISq6BC2rPoxQhFoKH1dKIwQc3GDFttQ/7m2OfeQ+tmQRzynv2dy/DXnxFCj2Lw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260811.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260811.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260811.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/worker/package.json
+++ b/worker/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test test/logic.test.mjs test/coordinator.test.mjs test/ranking.test.mjs",
-    "check": "node --check src/index.js && node --check src/logic.js && node --check ../ranking.js",
+    "test": "node --test test/logic.test.mjs test/coordinator.test.mjs test/ranking.test.mjs test/admin-logic.test.mjs",
+    "check": "node --check src/index.js && node --check src/logic.js && node --check ../ranking.js && node --check ../admin-logic.js",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy"
   },

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -36,19 +36,28 @@ const assertAllowedOrigin = (request, env) => {
   }
 };
 
-const githubHeaders = (env) => ({
+const assertAdminToken = (request) => {
+  const authorization = String(request.headers.get('Authorization') || '');
+  const token = authorization.replace(/^Bearer\s+/i, '').trim();
+  if (!token) {
+    throw new QueueError(401, 'admin_unauthorized', 'The admin save token is invalid.');
+  }
+  return token;
+};
+
+const githubHeaders = (env, token = env.GIST_TOKEN) => ({
   Accept: 'application/vnd.github+json',
-  Authorization: `Bearer ${env.GIST_TOKEN}`,
+  Authorization: `Bearer ${token}`,
   'User-Agent': 'howboutit-pick-queue',
   'X-GitHub-Api-Version': '2026-03-10'
 });
 
-const readPoolData = async (env) => {
-  if (!env.GIST_ID || !env.GIST_TOKEN) {
+const readPoolData = async (env, token = env.GIST_TOKEN) => {
+  if (!env.GIST_ID || !token) {
     throw new QueueError(503, 'worker_not_configured', 'The pick service is not configured yet.');
   }
   const response = await fetch(`https://api.github.com/gists/${env.GIST_ID}`, {
-    headers: githubHeaders(env),
+    headers: githubHeaders(env, token),
     cache: 'no-store'
   });
   if (!response.ok) {
@@ -66,11 +75,11 @@ const readPoolData = async (env) => {
   }
 };
 
-const writePoolData = async (env, data) => {
+const writePoolData = async (env, data, token = env.GIST_TOKEN) => {
   const response = await fetch(`https://api.github.com/gists/${env.GIST_ID}`, {
     method: 'PATCH',
     headers: {
-      ...githubHeaders(env),
+      ...githubHeaders(env, token),
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
@@ -107,8 +116,42 @@ export class PickQueueCoordinator {
 
   async handle(request) {
     const url = new URL(request.url);
-    if (url.pathname !== '/pick-queue') {
+    if (url.pathname !== '/pick-queue' && url.pathname !== '/admin-save') {
       return json({ error: 'not_found', message: 'Route not found.' }, 404);
+    }
+
+    if (url.pathname === '/admin-save') {
+      if (request.method !== 'POST') {
+        return json({ error: 'method_not_allowed', message: 'Method not allowed.' }, 405, { Allow: 'POST, OPTIONS' });
+      }
+      assertAllowedOrigin(request, this.env);
+      const adminToken = assertAdminToken(request);
+      const contentType = request.headers.get('Content-Type') || '';
+      if (!contentType.toLowerCase().includes('application/json')) {
+        throw new QueueError(415, 'json_required', 'Send the admin save as JSON.');
+      }
+
+      let saveRequest;
+      try {
+        saveRequest = await request.json();
+      } catch {
+        throw new QueueError(400, 'invalid_json', 'The admin save request is invalid.');
+      }
+      const baseline = saveRequest && saveRequest.baseline;
+      const nextData = saveRequest && saveRequest.data;
+      if (!baseline || !nextData || !Array.isArray(nextData.managers) || !nextData.pickQueue) {
+        throw new QueueError(422, 'invalid_pool_data', 'The admin save is missing required pool data.');
+      }
+      if (String(saveRequest.gistId || '') !== String(this.env.GIST_ID || '')) {
+        throw new QueueError(422, 'wrong_gist', 'The admin page is configured for a different Gist.');
+      }
+
+      const liveData = await readPoolData(this.env, adminToken);
+      if (JSON.stringify(liveData) !== JSON.stringify(baseline)) {
+        throw new QueueError(409, 'live_data_changed', 'The live pool changed after the admin page loaded. Reload before saving.');
+      }
+      await writePoolData(this.env, nextData, adminToken);
+      return json({ saved: true, lastUpdated: nextData.lastUpdated || null });
     }
 
     if (request.method === 'GET') {
@@ -152,7 +195,7 @@ export default {
         headers: {
           ...cors,
           'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-          'Access-Control-Allow-Headers': 'Content-Type',
+          'Access-Control-Allow-Headers': 'Content-Type, Authorization',
           'Access-Control-Max-Age': '86400'
         }
       });
@@ -163,7 +206,7 @@ export default {
       if (url.pathname === '/health') {
         return json({ status: 'ok', service: 'howboutit-pick-queue' }, 200, cors);
       }
-      if (url.pathname !== '/pick-queue') {
+      if (url.pathname !== '/pick-queue' && url.pathname !== '/admin-save') {
         return json({ error: 'not_found', message: 'Route not found.' }, 404, cors);
       }
       const id = env.PICK_QUEUE.idFromName(`season-${env.SEASON || '2026'}`);

--- a/worker/src/logic.js
+++ b/worker/src/logic.js
@@ -74,6 +74,7 @@ export const deriveQueueState = (data, now = new Date()) => {
   }
 
   const config = data.pickQueue || {};
+  const managers = data.managers;
   const activeWeek = Number(config.activeWeek || 1);
   const enabled = config.enabled === true;
   const deadline = activeDeadline(data, activeWeek);
@@ -116,12 +117,19 @@ export const deriveQueueState = (data, now = new Date()) => {
     };
   });
 
-  const usedTeams = new Set(
+  const usedByCurrentManager = new Set(
     (currentManager && Array.isArray(currentManager.picks) ? currentManager.picks : [])
       .filter((pick) => Number(pick && pick.week) !== activeWeek)
       .map((pick) => String(pick && pick.team || '').trim().toLowerCase())
       .filter(Boolean)
   );
+  const usedThisWeek = new Set(
+    managers
+      .map((manager) => findWeekPick(manager, activeWeek))
+      .map((pick) => String(pick && pick.team || '').trim().toLowerCase())
+      .filter(Boolean)
+  );
+  const unavailableTeams = new Set([...usedByCurrentManager, ...usedThisWeek]);
 
   return {
     season: Number(data.season),
@@ -138,7 +146,7 @@ export const deriveQueueState = (data, now = new Date()) => {
     } : null,
     entries,
     availableTeams: currentManager
-      ? NFL_TEAMS.filter((team) => !usedTeams.has(team.toLowerCase()))
+      ? NFL_TEAMS.filter((team) => !unavailableTeams.has(team.toLowerCase()))
       : [],
     lastUpdated: data.lastUpdated || null,
     lastSubmission: config.lastSubmission || null
@@ -172,8 +180,25 @@ export const applySubmission = (data, submission, now = new Date()) => {
   if (!team) {
     throw new QueueError(422, 'invalid_team', 'Choose a valid NFL team.');
   }
-  if (!state.availableTeams.includes(team)) {
+
+  const liveManager = data.managers.find((candidate) => managerKey(candidate.name) === managerKey(state.currentManager.name));
+  const weeklyOwner = data.managers.find((candidate) => {
+    if (managerKey(candidate.name) === managerKey(state.currentManager.name)) return false;
+    const pick = findWeekPick(candidate, state.activeWeek);
+    return String(pick && pick.team || '').trim().toLowerCase() === requestedTeamKey;
+  });
+  if (weeklyOwner) {
+    throw new QueueError(409, 'team_taken_this_week', `${team} was already picked by ${weeklyOwner.name} for Week ${state.activeWeek}. Choose another team.`);
+  }
+
+  const reusedByManager = (Array.isArray(liveManager && liveManager.picks) ? liveManager.picks : [])
+    .some((pick) => Number(pick && pick.week) !== state.activeWeek
+      && String(pick && pick.team || '').trim().toLowerCase() === requestedTeamKey);
+  if (reusedByManager) {
     throw new QueueError(409, 'team_already_used', `${state.currentManager.name} already used ${team} in another week.`);
+  }
+  if (!state.availableTeams.includes(team)) {
+    throw new QueueError(409, 'team_unavailable', `${team} is unavailable. Choose another team.`);
   }
 
   const updated = structuredClone(data);

--- a/worker/src/logic.js
+++ b/worker/src/logic.js
@@ -214,6 +214,8 @@ export const applySubmission = (data, submission, now = new Date()) => {
   const submittedAt = (now instanceof Date ? now : new Date(now)).toISOString();
   pick.team = team;
   pick.result = null;
+  pick.margin = 0;
+  pick.manualResult = false;
   pick.submittedBy = 'public-pick-queue';
   pick.submittedAt = submittedAt;
   pick.lastUpdated = submittedAt;

--- a/worker/test/admin-logic.test.mjs
+++ b/worker/test/admin-logic.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import AdminLogic from '../../admin-logic.js';
+
+const manager = (name, lastYearRank, weekOneTeam, result = null, margin = 0, extraPick = {}) => ({
+  name,
+  teamLabel: `${name} Team`,
+  lastYearRank,
+  eliminated: false,
+  picks: [
+    { week: 1, team: weekOneTeam, result, margin, ...extraPick },
+    { week: 2, team: '', result: null, margin: 0 },
+    { week: 3, team: '', result: null, margin: 0 }
+  ]
+});
+
+const data = (managers, activeWeek = 1) => ({
+  season: 2026,
+  managers,
+  pickQueue: { enabled: true, activeWeek, orderModes: { '1': 'manual', '2': 'standings', '3': 'standings' } }
+});
+
+const finalGame = (homeTeam, homeScore, awayTeam, awayScore) => ({
+  status: { type: { state: 'post' } },
+  competitions: [{
+    competitors: [
+      { homeAway: 'home', score: String(homeScore), team: { displayName: homeTeam } },
+      { homeAway: 'away', score: String(awayScore), team: { displayName: awayTeam } }
+    ]
+  }]
+});
+
+test('finalization imports finals, preserves valid manual overrides, and closes the next queue', () => {
+  const pool = data([
+    manager('Alice', 2, 'Buffalo Bills'),
+    manager('Bob', 1, 'Miami Dolphins', 'L', -3, { manualResult: true })
+  ]);
+  const result = AdminLogic.finalizePoolWeek(
+    pool,
+    [finalGame('Buffalo Bills', 20, 'New York Jets', 10)],
+    1,
+    '2026-08-15T00:00:00.000Z'
+  );
+
+  assert.equal(result.finalized, true);
+  assert.equal(result.advanced, true);
+  assert.equal(result.data.pickQueue.activeWeek, 2);
+  assert.equal(result.data.pickQueue.enabled, false);
+  assert.equal(result.data.managers[0].picks[0].result, 'W');
+  assert.equal(result.data.managers[0].picks[0].margin, 10);
+  assert.equal(result.data.managers[1].picks[0].margin, -3);
+  assert.equal(result.data.managers[1].eliminated, true);
+});
+
+test('finalization does not advance while an eligible game is unfinished', () => {
+  const pool = data([manager('Alice', 1, 'Buffalo Bills')]);
+  const result = AdminLogic.finalizePoolWeek(pool, [], 1, '2026-08-15T00:00:00.000Z');
+
+  assert.equal(result.finalized, false);
+  assert.equal(result.data.pickQueue.activeWeek, 1);
+  assert.match(result.errors[0], /not final yet/);
+});
+
+test('an inconsistent manual result and margin cannot advance the week', () => {
+  const pool = data([manager('Alice', 1, 'Buffalo Bills', 'W', 0, { manualResult: true })]);
+  const result = AdminLogic.finalizePoolWeek(pool, [], 1, '2026-08-15T00:00:00.000Z');
+
+  assert.equal(result.finalized, false);
+  assert.match(result.errors[0], /positive margin/);
+});
+
+test('ties are stored as final results with a zero margin', () => {
+  const pool = data([manager('Alice', 1, 'Buffalo Bills')]);
+  const result = AdminLogic.finalizePoolWeek(
+    pool,
+    [finalGame('Buffalo Bills', 17, 'New York Jets', 17)],
+    1,
+    '2026-08-15T00:00:00.000Z'
+  );
+
+  assert.equal(result.finalized, true);
+  assert.equal(result.data.managers[0].picks[0].result, 'T');
+  assert.equal(result.data.managers[0].picks[0].margin, 0);
+  assert.equal(result.data.managers[0].eliminated, false);
+});
+
+test('a stale future-week loss cannot eliminate a manager during current-week finalization', () => {
+  const alice = manager('Alice', 1, 'Buffalo Bills');
+  alice.picks[1] = { week: 2, team: 'Miami Dolphins', result: 'L', margin: -40 };
+  const result = AdminLogic.finalizePoolWeek(
+    data([alice]),
+    [finalGame('Buffalo Bills', 20, 'New York Jets', 10)],
+    1,
+    '2026-08-15T00:00:00.000Z'
+  );
+
+  assert.equal(result.finalized, true);
+  assert.equal(result.data.managers[0].eliminated, false);
+  assert.equal(result.data.managers[0].eliminationWeek, null);
+});
+
+test('a manager eliminated in a prior week is not required to pick in the next week', () => {
+  const survivor = manager('Alice', 1, 'Buffalo Bills', 'W', 7);
+  survivor.picks[1] = { week: 2, team: 'Miami Dolphins', result: null, margin: 0 };
+  const eliminated = manager('Bob', 2, 'New York Jets', 'L', -7);
+  eliminated.eliminated = true;
+  eliminated.eliminationWeek = 1;
+  const pool = data([survivor, eliminated], 2);
+  const result = AdminLogic.finalizePoolWeek(
+    pool,
+    [finalGame('Miami Dolphins', 24, 'Tampa Bay Buccaneers', 14)],
+    2,
+    '2026-08-22T00:00:00.000Z'
+  );
+
+  assert.equal(result.finalized, true);
+  assert.equal(result.data.pickQueue.activeWeek, 3);
+  assert.equal(result.errors.length, 0);
+});
+
+test('if everyone is eliminated in the same week, the pool closes without opening an empty week', () => {
+  const pool = data([
+    manager('Alice', 1, 'Buffalo Bills'),
+    manager('Bob', 2, 'Miami Dolphins')
+  ]);
+  const result = AdminLogic.finalizePoolWeek(
+    pool,
+    [
+      finalGame('Buffalo Bills', 10, 'New York Jets', 20),
+      finalGame('Miami Dolphins', 7, 'Tampa Bay Buccaneers', 14)
+    ],
+    1,
+    '2026-08-15T00:00:00.000Z'
+  );
+
+  assert.equal(result.finalized, true);
+  assert.equal(result.poolComplete, true);
+  assert.equal(result.advanced, false);
+  assert.equal(result.data.pickQueue.activeWeek, 1);
+  assert.equal(result.data.pickQueue.enabled, false);
+  assert.equal(result.data.pickQueue.completed, true);
+});

--- a/worker/test/coordinator.test.mjs
+++ b/worker/test/coordinator.test.mjs
@@ -36,6 +36,16 @@ const submissionRequest = (manager, team) => new Request('https://worker.example
   body: JSON.stringify({ manager, week: 1, team })
 });
 
+const adminSaveRequest = (baseline, nextData) => new Request('https://worker.example/admin-save', {
+  method: 'POST',
+  headers: {
+    Origin: 'https://enjoinick.github.io',
+    Authorization: 'Bearer test-token',
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({ gistId: 'test-gist', baseline, data: nextData })
+});
+
 test('coordinator serializes simultaneous valid turns against the latest Gist state', async () => {
   let liveData = buildData();
   const originalFetch = globalThis.fetch;
@@ -122,6 +132,72 @@ test('coordinator rejects the same team for consecutive managers', async () => {
     assert.equal(jordanResponse.status, 409);
     assert.equal(payload.error, 'team_taken_this_week');
     assert.equal(liveData.managers[1].picks[0].team, '');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('a public pick landing before an admin save causes a safe conflict instead of data loss', async () => {
+  const baseline = buildData();
+  let liveData = structuredClone(baseline);
+  const adminData = structuredClone(baseline);
+  adminData.managers[0].teamLabel = 'Commissioner Edit';
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, options = {}) => {
+    if ((options.method || 'GET') === 'PATCH') {
+      const payload = JSON.parse(options.body);
+      liveData = JSON.parse(payload.files['data.json'].content);
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      files: { 'data.json': { content: JSON.stringify(liveData), truncated: false } }
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  try {
+    const coordinator = new PickQueueCoordinator({}, env);
+    const [pickResponse, saveResponse] = await Promise.all([
+      coordinator.fetch(submissionRequest('Weston', 'Jacksonville Jaguars')),
+      coordinator.fetch(adminSaveRequest(baseline, adminData))
+    ]);
+    const savePayload = await saveResponse.json();
+    assert.equal(pickResponse.status, 201);
+    assert.equal(saveResponse.status, 409);
+    assert.equal(savePayload.error, 'live_data_changed');
+    assert.equal(liveData.managers[0].picks[0].team, 'Jacksonville Jaguars');
+    assert.notEqual(liveData.managers[0].teamLabel, 'Commissioner Edit');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('a public pick landing after an admin save retains the commissioner edit', async () => {
+  const baseline = buildData();
+  let liveData = structuredClone(baseline);
+  const adminData = structuredClone(baseline);
+  adminData.managers[0].teamLabel = 'Commissioner Edit';
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, options = {}) => {
+    if ((options.method || 'GET') === 'PATCH') {
+      const payload = JSON.parse(options.body);
+      liveData = JSON.parse(payload.files['data.json'].content);
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      files: { 'data.json': { content: JSON.stringify(liveData), truncated: false } }
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  try {
+    const coordinator = new PickQueueCoordinator({}, env);
+    const [saveResponse, pickResponse] = await Promise.all([
+      coordinator.fetch(adminSaveRequest(baseline, adminData)),
+      coordinator.fetch(submissionRequest('Weston', 'Jacksonville Jaguars'))
+    ]);
+    assert.equal(saveResponse.status, 200);
+    assert.equal(pickResponse.status, 201);
+    assert.equal(liveData.managers[0].teamLabel, 'Commissioner Edit');
+    assert.equal(liveData.managers[0].picks[0].team, 'Jacksonville Jaguars');
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/worker/test/coordinator.test.mjs
+++ b/worker/test/coordinator.test.mjs
@@ -93,3 +93,36 @@ test('coordinator returns a conflict response for an out-of-order turn', async (
     globalThis.fetch = originalFetch;
   }
 });
+
+test('coordinator rejects the same team for consecutive managers', async () => {
+  let liveData = buildData();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, options = {}) => {
+    if ((options.method || 'GET') === 'PATCH') {
+      const payload = JSON.parse(options.body);
+      liveData = JSON.parse(payload.files['data.json'].content);
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      files: {
+        'data.json': {
+          content: JSON.stringify(liveData),
+          truncated: false
+        }
+      }
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  try {
+    const coordinator = new PickQueueCoordinator({}, env);
+    const westonResponse = await coordinator.fetch(submissionRequest('Weston', 'Jacksonville Jaguars'));
+    const jordanResponse = await coordinator.fetch(submissionRequest('Jordan', 'Jacksonville Jaguars'));
+    const payload = await jordanResponse.json();
+    assert.equal(westonResponse.status, 201);
+    assert.equal(jordanResponse.status, 409);
+    assert.equal(payload.error, 'team_taken_this_week');
+    assert.equal(liveData.managers[1].picks[0].team, '');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/worker/test/logic.test.mjs
+++ b/worker/test/logic.test.mjs
@@ -86,6 +86,20 @@ test('a manager cannot reuse a team from an earlier week', () => {
   );
 });
 
+test('a team already picked by another manager is unavailable that week', () => {
+  const data = buildData();
+  data.managers[0].picks[0].team = 'Jacksonville Jaguars';
+  const state = deriveQueueState(data, beforeDeadline);
+  assert.equal(state.currentManager.name, 'Jordan');
+  assert.equal(state.availableTeams.includes('Jacksonville Jaguars'), false);
+  assert.throws(
+    () => applySubmission(data, { manager: 'Jordan', week: 1, team: 'Jacksonville Jaguars' }, beforeDeadline),
+    (error) => error instanceof QueueError
+      && error.code === 'team_taken_this_week'
+      && error.message.includes('Weston')
+  );
+});
+
 test('eliminated managers are skipped unless buyback is active', () => {
   const data = buildData();
   data.managers[0].eliminated = true;

--- a/worker/test/logic.test.mjs
+++ b/worker/test/logic.test.mjs
@@ -70,6 +70,28 @@ test('an accepted pick advances exactly one turn', () => {
   assert.equal(result.queue.entries[1].status, 'current');
 });
 
+test('an accepted pick clears stale result state from an empty slot', () => {
+  const pool = buildData();
+  pool.managers[0].picks[0] = {
+    week: 1,
+    team: '',
+    result: 'W',
+    margin: 14,
+    manualResult: true,
+    submittedAt: '2025-08-01T00:00:00.000Z'
+  };
+  const result = applySubmission(pool, {
+    manager: 'Weston',
+    week: 1,
+    team: 'Jacksonville Jaguars'
+  }, beforeDeadline);
+  const pick = result.data.managers[0].picks[0];
+  assert.equal(pick.result, null);
+  assert.equal(pick.margin, 0);
+  assert.equal(pick.manualResult, false);
+  assert.equal(pick.submittedAt, beforeDeadline.toISOString());
+});
+
 test('out-of-order submissions are rejected', () => {
   assert.throws(
     () => applySubmission(buildData(), { manager: 'Jordan', week: 1, team: 'Buffalo Bills' }, beforeDeadline),


### PR DESCRIPTION
## What changed

- Show public pick-submission failures in the confirmation dialog and allow retrying.
- Enforce one unique NFL team per manager per week in both the browser and serialized Worker.
- Serialize commissioner saves with public submissions so neither can overwrite newer live picks.
- Add guarded week finalization that imports ESPN finals, validates picks and margins, recomputes eliminations, and stages the next week with the queue closed.
- Scope live score updates to the matching pool week and add complete tie handling.
- Clear stale result, margin, override, and submission metadata when a pick is corrected.
- Close the pool cleanly when everyone is eliminated in the same week.

## Why

The public queue and commissioner page both wrote the complete Gist document. Without a shared serialized save path, a stale admin tab could erase a recently submitted pick. Week advancement could also happen before all results were final, and score matching used only a team name, allowing a later ESPN week to affect an earlier stored pick.

## Impact

Managers keep the existing no-login pick flow and strict turn order. Commissioner saves now stop safely when newer live data exists. Weeks cannot advance until every eligible pick has a valid final result and margin, and the resulting survivor/elimination order is calculated only through the completed week.

## Validation

- `npm test` — 33 tests passed
- `npm run check`
- Concurrency tests for public picks before and after commissioner saves
- Local browser verification of guarded advancement, pick correction cleanup, and both site pages
- Production Worker health, CORS, and unauthorized-write checks